### PR TITLE
Add support for RHS-only rules

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -274,9 +274,13 @@ impl ExecutionState<'_> {
 
 impl ExecutionState<'_> {
     pub(crate) fn run_instrs(&mut self, instrs: &[Instr], bindings: &mut Bindings) {
+        if bindings.next_id().rep() == 0 {
+            // Run instructions once if no variables are bound.
+            bindings.push(Pooled::new(vec![Value::new(0)]));
+        }
         let Some(batch_size) = bindings.iter().map(|(_, x)| x.len()).next() else {
-            // Empty bindings; nothing to do.
-            return;
+            // Bindings cannot be empty (see above)
+            unreachable!()
         };
         with_pool_set(|ps| {
             let mut mask = Mask::new(0..batch_size, ps);

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -61,11 +61,6 @@ impl Timestamp {
 pub struct EGraph {
     db: Database,
     uf_table: TableId,
-    /// A table with a single element used to bind a placeholder variable for right-hand-side only
-    /// rules. core-relations requires at least one variable to be bound on the LHS of a rule
-    /// before the RHS can be run. Egglog supports rules that only specify a right-hand side but
-    /// run once.
-    placeholder_table: TableId,
     id_counter: CounterId,
     reason_counter: CounterId,
     timestamp_counter: CounterId,
@@ -110,15 +105,6 @@ impl EGraph {
         let id_counter = db.add_counter();
         let trace_counter = db.add_counter();
         let ts_counter = db.add_counter();
-        let placeholder_table = db.add_table(
-            SortedWritesTable::new(1, 1, None, vec![], |_, _, _, _| false),
-            iter::empty(),
-            iter::empty(),
-        );
-        db.get_table(placeholder_table)
-            .new_buffer()
-            .stage_insert(&[Value::new(0)]);
-        db.merge_table(placeholder_table);
         // Start the timestamp counter at 1.
         db.inc_counter(ts_counter);
 
@@ -126,7 +112,6 @@ impl EGraph {
             db,
             uf_table,
             id_counter,
-            placeholder_table,
             reason_counter: trace_counter,
             timestamp_counter: ts_counter,
             rules: Default::default(),

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -61,6 +61,11 @@ impl Timestamp {
 pub struct EGraph {
     db: Database,
     uf_table: TableId,
+    /// A table with a single element used to bind a placeholder variable for right-hand-side only
+    /// rules. core-relations requires at least one variable to be bound on the LHS of a rule
+    /// before the RHS can be run. Egglog supports rules that only specify a right-hand side but
+    /// run once.
+    placeholder_table: TableId,
     id_counter: CounterId,
     reason_counter: CounterId,
     timestamp_counter: CounterId,
@@ -105,6 +110,15 @@ impl EGraph {
         let id_counter = db.add_counter();
         let trace_counter = db.add_counter();
         let ts_counter = db.add_counter();
+        let placeholder_table = db.add_table(
+            SortedWritesTable::new(1, 1, None, vec![], |_, _, _, _| false),
+            iter::empty(),
+            iter::empty(),
+        );
+        db.get_table(placeholder_table)
+            .new_buffer()
+            .stage_insert(&[Value::new(0)]);
+        db.merge_table(placeholder_table);
         // Start the timestamp counter at 1.
         db.inc_counter(ts_counter);
 
@@ -112,6 +126,7 @@ impl EGraph {
             db,
             uf_table,
             id_counter,
+            placeholder_table,
             reason_counter: trace_counter,
             timestamp_counter: ts_counter,
             rules: Default::default(),

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -723,6 +723,9 @@ fn rhs_only_rule() {
     };
 
     let mut contents = Vec::new();
+    egraph.dump_table(num_table, |vals| {
+        contents.push(vals.to_vec());
+    });
 
     assert!(contents.is_empty());
     assert!(egraph.run_rules(&[add_data]).unwrap());


### PR DESCRIPTION
A few notes here:

* The whole structure of running actions is subject to some set of variable bindings that are nonempty. RHS-only rules have no such bindings, so they don't run.
* To fix this, we add a placeholder variable binding for any rule that doesn't have any atoms
* Is this the right thing, or should this behavior be opt in (e.g. behind a `run_rhs` option on `RuleBuilder` ?). Does egglog support empty LHSs in normal rules, and does it run the RHS once if that happens?