### PR TITLE
Bindings invariant

### DIFF
--- a/core-relations/src/action/mask.rs
+++ b/core-relations/src/action/mask.rs
@@ -13,11 +13,11 @@ use crate::{
 /// A subset of offsets that are still active.
 #[derive(Debug)]
 pub(crate) struct Mask {
-    // NB: why keep track of an extra length? Different bitset operations (e.g.
-    // symmetric_difference) can increase the length of a bitset up to the total capacity, and the
-    // capacity of the bitset may be larger than the initial length of the range we are targetting.
-    // This can lead to later bindings being longer (albeit, filled with stale enttries) than
-    // earlier ones, which violates an invariant of the Bindings struct.
+    // NB: why keep track of an extra length? We call `clear` on bitsets when we add them to the
+    // memory pool, and that bitset may have a larger length than the size of the max we construct.
+    //
+    // To keep the length of the mask consistent regardless of the contents of the pool, we use
+    // `len` to cap iteration of the bitset at number of elements passed to `new`.
     len: usize,
     data: Pooled<FixedBitSet>,
 }

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -95,7 +95,7 @@ impl From<Value> for MergeVal {
 /// Bindings store a sequence of values for a given set of variables.
 ///
 /// The intent of bindings is to store a sequence of mappings from [`Variable`] to [`Value`], in a
-/// struct-of-arrays style form that is better laid out for processing bindings in batches.
+/// struct-of-arrays style that is better laid out for processing bindings in batches.
 #[derive(Debug, Default)]
 pub(crate) struct Bindings {
     // INVARIANT: self.vars.iter().map(|(_, v)| v.len() == self.matches)

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -92,6 +92,10 @@ impl From<Value> for MergeVal {
     }
 }
 
+/// Bindings store a sequence of values for a given set of variables.
+///
+/// The intent of bindings is to store a sequence of mappings from [`Variable`] to [`Value`], in a
+/// struct-of-arrays style form that is better laid out for processing bindings in batches.
 #[derive(Debug, Default)]
 pub(crate) struct Bindings {
     // INVARIANT: self.vars.iter().map(|(_, v)| v.len() == self.matches)

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -112,8 +112,11 @@ impl std::ops::Index<Variable> for Bindings {
 
 impl Bindings {
     fn assert_invariant(&self) {
-        for (_, v) in self.vars.iter() {
-            assert_eq!(v.len(), self.matches);
+        #[cfg(debug_assertions)]
+        {
+            for (_, v) in self.vars.iter() {
+                assert_eq!(v.len(), self.matches);
+            }
         }
     }
 

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -169,13 +169,13 @@ impl Database {
     }
     pub fn run_rule_set(&mut self, rule_set: &RuleSet) -> bool {
         fn do_parallel() -> bool {
-            #[cfg(test)]
+            #[cfg(debug_assertions)]
             {
                 use rand::Rng;
                 rand::thread_rng().gen_bool(0.5)
             }
 
-            #[cfg(not(test))]
+            #[cfg(not(debug_assertions))]
             {
                 rayon::current_num_threads() > 1
             }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -859,12 +859,7 @@ impl<'a, 'outer: 'a> ActionBuffer<'a> for InPlaceActionBuffer<'outer> {
         let action_state = self.batches.get_or_default(action);
         action_state.n_runs += 1;
         action_state.len += 1;
-        with_pool_set(|ps| {
-            for (var, val) in bindings.iter() {
-                let vals = action_state.bindings.get_or_insert(var, || ps.get());
-                vals.push(*val);
-            }
-        });
+        action_state.bindings.push(bindings);
         if action_state.len > VAR_BATCH_SIZE {
             let mut state = to_exec_state();
             state.run_instrs(&self.rule_set.actions[action], &mut action_state.bindings);
@@ -920,12 +915,7 @@ impl<'scope> ActionBuffer<'scope> for ScopedActionBuffer<'_, 'scope> {
         let action_state = self.batches.get_or_default(action);
         action_state.n_runs += 1;
         action_state.len += 1;
-        with_pool_set(|ps| {
-            for (var, val) in bindings.iter() {
-                let vals = action_state.bindings.get_or_insert(var, || ps.get());
-                vals.push(*val);
-            }
-        });
+        action_state.bindings.push(bindings);
         if action_state.len > VAR_BATCH_SIZE {
             let mut state = to_exec_state();
             let mut bindings = mem::take(&mut action_state.bindings);

--- a/core-relations/src/pool/mod.rs
+++ b/core-relations/src/pool/mod.rs
@@ -139,7 +139,7 @@ impl<T> Clear for IndexSet<T> {
 
 impl Clear for FixedBitSet {
     fn clear(&mut self) {
-        self.clear();
+        self.clone_from(&Default::default());
     }
     fn reuse(&self) -> bool {
         !self.is_empty()


### PR DESCRIPTION
Wraps the `Bindings` map with a runtime check that all vectors are the same length.

TODO:
- fix failing tests
- remove `assert_invariants` (or make it debug-mode only)