### PR TITLE
Add support for RHS-only rules

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -336,6 +336,10 @@ impl ExecutionState<'_> {
 
 impl ExecutionState<'_> {
     pub(crate) fn run_instrs(&mut self, instrs: &[Instr], bindings: &mut Bindings) {
+        if bindings.vars.next_id().rep() == 0 {
+            // If we have no variables, we want to run the rules once.
+            bindings.matches = 1;
+        }
         with_pool_set(|ps| {
             let mut mask = Mask::new(0..bindings.matches, ps);
             for instr in instrs {

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -907,7 +907,9 @@ impl Query {
             }
         }
         // For N atoms, we create N queries for seminaive evaluation.
-        if !self.seminaive {
+        if !self.seminaive || (self.atoms.is_empty() && mid_ts == Timestamp::new(0)) {
+            // If a rule has an empty LHS, we still want to run it once. This will cause the right
+            // hand side of the rule to run once, globally across all runs.
             let (mut qb, inner) = self.query_state(rsb, next_ts);
             for (table, entries) in &self.atoms {
                 let dst_vars = inner.convert_all(entries);


### PR DESCRIPTION
This is a redo of #1 with fewer hacks, and using the improvements to `Bindings` from #2 .