### PR TITLE
Fix support for primitives that constrain one anothers' output

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -105,7 +105,9 @@ pub(crate) struct Bindings {
 impl std::ops::Index<Variable> for Bindings {
     type Output = Pooled<Vec<Value>>;
     fn index(&self, var: Variable) -> &Pooled<Vec<Value>> {
-        &self.vars[var]
+        self.vars
+            .get(var)
+            .unwrap_or_else(|| panic!("variable {var:?} not found"))
     }
 }
 
@@ -356,6 +358,7 @@ impl ExecutionState<'_> {
         bindings: &mut Bindings,
         pool_set: &PoolSet,
     ) {
+        let todo_remove = eprintln!("running instr {inst:?} with bindings {bindings:?}");
         fn assert_impl(
             bindings: &mut Bindings,
             mask: &mut Mask,

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -358,7 +358,6 @@ impl ExecutionState<'_> {
         bindings: &mut Bindings,
         pool_set: &PoolSet,
     ) {
-        let todo_remove = eprintln!("running instr {inst:?} with bindings {bindings:?}");
         fn assert_impl(
             bindings: &mut Bindings,
             mask: &mut Mask,

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -13,7 +13,9 @@ use log::debug;
 use num_rational::Rational64;
 use numeric_id::NumericId;
 
-use crate::{add_expressions, define_rule, ColumnTy, DefaultVal, EGraph, MergeFn, QueryEntry};
+use crate::{
+    add_expressions, define_rule, ColumnTy, DefaultVal, EGraph, FunctionId, MergeFn, QueryEntry,
+};
 
 #[test]
 fn ac() {
@@ -1026,6 +1028,173 @@ fn mergefn_nested_function() {
     assert_eq!(base_l1, base_2);
     assert_eq!(base_r1, base_r2);
     assert_eq!(base_r1, base_1);
+}
+
+#[test]
+fn constrain_prims_simple() {
+    // Take two functions, f and g. Fill f with (f 1) (f 2) (f 3), then filter for even numbers
+    // when adding to 'g'. This should only add 2 to g.
+    let mut egraph = EGraph::default();
+    let int_prim = egraph.primitives_mut().register_type::<i64>();
+    let bool_prim = egraph.primitives_mut().register_type::<bool>();
+    let f_table = egraph.add_table(
+        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        DefaultVal::FreshId,
+        MergeFn::UnionId,
+        "f",
+    );
+    let g_table = egraph.add_table(
+        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        DefaultVal::FreshId,
+        MergeFn::UnionId,
+        "g",
+    );
+
+    let is_even = egraph.register_external_func(core_relations::make_external_func(
+        |state, vals| -> Option<Value> {
+            let [a] = vals else {
+                return None;
+            };
+            let a_val = *state.prims().unwrap_ref::<i64>(*a);
+            let result: bool = a_val % 2 == 0;
+            Some(state.prims().get(result))
+        },
+    ));
+
+    let value_1 = egraph.primitive_constant(1i64);
+    let value_2 = egraph.primitive_constant(2i64);
+    let value_3 = egraph.primitive_constant(3i64);
+    let value_true = egraph.primitive_constant(true);
+    let write_f = {
+        let mut rb = egraph.new_rule("write_f", true);
+        rb.lookup(f_table, &[value_1.clone()]);
+        rb.lookup(f_table, &[value_2.clone()]);
+        rb.lookup(f_table, &[value_3.clone()]);
+        rb.build()
+    };
+
+    let copy_to_g = {
+        let mut rb = egraph.new_rule("copy_to_g", true);
+        let val = rb.new_var(ColumnTy::Primitive(int_prim));
+        let id = rb.new_var(ColumnTy::Id);
+        rb.query_table(f_table, &[val.into(), id.into()]).unwrap();
+        rb.query_prim(
+            is_even,
+            &[val.into(), value_true.clone()],
+            ColumnTy::Primitive(bool_prim),
+        )
+        .unwrap();
+        rb.set(g_table, &[val.into(), id.into()]);
+        rb.build()
+    };
+    let get_entries = |egraph: &EGraph, table: FunctionId| {
+        let mut entries = Vec::new();
+        egraph.dump_table(table, |vals| {
+            entries.push((*egraph.primitives().unwrap_ref::<i64>(vals[0]), vals[1]));
+        });
+        entries.sort();
+        entries
+    };
+
+    assert!(get_entries(&egraph, f_table).is_empty());
+    assert!(get_entries(&egraph, g_table).is_empty());
+    egraph.run_rules(&[write_f]).unwrap();
+    let f = get_entries(&egraph, f_table);
+    assert_eq!(f.len(), 3);
+    egraph.run_rules(&[copy_to_g]).unwrap();
+    let g = get_entries(&egraph, g_table);
+    assert_eq!(g.len(), 1);
+    assert_eq!(g[0], f[1])
+}
+
+#[test]
+fn constrain_prims_abstract() {
+    // Take two functions, f and g. Fill f with (f -1) (f 0) (f 1), then filter for numbers where
+    // (neg x) = (abs x) when adding to 'g'. This adds only -1 and 0 to g
+    let mut egraph = EGraph::default();
+    let int_prim = egraph.primitives_mut().register_type::<i64>();
+    let f_table = egraph.add_table(
+        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        DefaultVal::FreshId,
+        MergeFn::UnionId,
+        "f",
+    );
+    let g_table = egraph.add_table(
+        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        DefaultVal::FreshId,
+        MergeFn::UnionId,
+        "g",
+    );
+
+    let neg = egraph.register_external_func(core_relations::make_external_func(
+        |state, vals| -> Option<Value> {
+            let [a] = vals else {
+                return None;
+            };
+            let a_val = *state.prims().unwrap_ref::<i64>(*a);
+            Some(state.prims().get(-a_val))
+        },
+    ));
+    let abs = egraph.register_external_func(core_relations::make_external_func(
+        |state, vals| -> Option<Value> {
+            let [a] = vals else {
+                return None;
+            };
+            let a_val = *state.prims().unwrap_ref::<i64>(*a);
+            Some(state.prims().get(a_val.abs()))
+        },
+    ));
+
+    let value_n1 = egraph.primitive_constant(-1i64);
+    let value_0 = egraph.primitive_constant(0i64);
+    let value_1 = egraph.primitive_constant(1i64);
+    let write_f = {
+        let mut rb = egraph.new_rule("write_f", true);
+        rb.lookup(f_table, &[value_n1.clone()]);
+        rb.lookup(f_table, &[value_0.clone()]);
+        rb.lookup(f_table, &[value_1.clone()]);
+        rb.build()
+    };
+
+    let copy_to_g = {
+        let mut rb = egraph.new_rule("copy_to_g", true);
+        let val = rb.new_var(ColumnTy::Primitive(int_prim));
+        let id = rb.new_var(ColumnTy::Id);
+        let negval = rb.new_var(ColumnTy::Primitive(int_prim));
+        rb.query_table(f_table, &[val.into(), id.into()]).unwrap();
+        rb.query_prim(
+            neg,
+            &[val.into(), negval.into()],
+            ColumnTy::Primitive(int_prim),
+        )
+        .unwrap();
+        rb.query_prim(
+            abs,
+            &[val.into(), negval.into()],
+            ColumnTy::Primitive(int_prim),
+        )
+        .unwrap();
+        rb.set(g_table, &[val.into(), id.into()]);
+        rb.build()
+    };
+    let get_entries = |egraph: &EGraph, table: FunctionId| {
+        let mut entries = Vec::new();
+        egraph.dump_table(table, |vals| {
+            entries.push((*egraph.primitives().unwrap_ref::<i64>(vals[0]), vals[1]));
+        });
+        entries.sort();
+        entries
+    };
+
+    assert!(get_entries(&egraph, f_table).is_empty());
+    assert!(get_entries(&egraph, g_table).is_empty());
+    egraph.run_rules(&[write_f]).unwrap();
+    let f = get_entries(&egraph, f_table);
+    assert_eq!(f.len(), 3);
+    egraph.run_rules(&[copy_to_g]).unwrap();
+    let g = get_entries(&egraph, g_table);
+    assert_eq!(g.len(), 2);
+    assert_eq!(g, f[0..2])
 }
 
 const _: () = {

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -795,7 +795,7 @@ fn rhs_only_rule_only_runs_once() {
 }
 
 #[test]
-fn test_mergefn_arithmetic() {
+fn mergefn_arithmetic() {
     let mut egraph = EGraph::default();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
 
@@ -915,7 +915,7 @@ fn test_mergefn_arithmetic() {
 }
 
 #[test]
-fn test_mergefn_nested_function() {
+fn mergefn_nested_function() {
     let mut egraph = EGraph::default();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
 


### PR DESCRIPTION
This change adds support for cases like:

```
(my-relation y z)
(= x (f y))
(= x (g z))
```
Where `f` and `g` are primitives. It works by finding the first time `x` is used in return position and then binding the value there. The rest of the code remains unchanged and correctly asserts that the output of `g` matches.

The precise rules for what kinds of queries on primitives are allowed in egglog aren't super clear to me (e.g. if `y` and `z` weren't already bound by `my-relation` then egglog can't answer), but I suspect that this gets us pretty close.  It fixes the bignums test in the backend-merge egglog branch:

```
%  cargo run -- tests/bignum.egg
   Compiling core-relations v0.1.0 (/Users/elirosenthal/CS/egglog-backend/core-relations)
   Compiling egglog-bridge v0.1.0 (/Users/elirosenthal/CS/egglog-backend/egglog-bridge)
   Compiling egglog v0.4.0 (/Users/elirosenthal/CS/egglog)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.15s
     Running `target/debug/egglog tests/bignum.egg`
[INFO ] Declared function x.
[INFO ] Declared function y.
[INFO ] Declared function z.
[INFO ] Checked fact [Eq(In 5:8-39 of tests/bignum.egg: (= (to-string (numer z)) "-617"), Call(In 5:11-31 of tests/bignum.egg: (to-string (numer z)), Primitive(SpecializedPrimitive { primitive: Prim(to-string), input: [BigIntSort], output: StringSort }), [Call(In 5:22-30 of tests/bignum.egg: (numer z), Primitive(SpecializedPrimitive { primitive: Prim(numer), input: [BigRatSort], output: BigIntSort }), [Call(In 5:29-29 of tests/bignum.egg: z, Func(FuncType { name: "z", subtype: Custom, input: [], output: BigRatSort }), [])])]), Lit(In 5:33-38 of tests/bignum.egg: "-617", String("-617")))].
[INFO ] Declared function bignums.
[INFO ] Checked fact [Eq(In 10:2-20 of tests/bignum.egg: (= (bignums a b) c), Call(In 10:5-17 of tests/bignum.egg: (bignums a b), Func(FuncType { name: "bignums", subtype: Custom, input: [BigIntSort, BigIntSort], output: BigRatSort }), [Var(In 10:14-14 of tests/bignum.egg: a, ResolvedVar { name: "a", sort: BigIntSort, is_global_ref: false }), Var(In 10:16-16 of tests/bignum.egg: b, ResolvedVar { name: "b", sort: BigIntSort, is_global_ref: false })]), Var(In 10:19-19 of tests/bignum.egg: c, ResolvedVar { name: "c", sort: BigRatSort, is_global_ref: false })), Eq(In 11:2-23 of tests/bignum.egg: (= (numer c) (>> a 1)), Call(In 11:5-13 of tests/bignum.egg: (numer c), Primitive(SpecializedPrimitive { primitive: Prim(numer), input: [BigRatSort], output: BigIntSort }), [Var(In 11:12-12 of tests/bignum.egg: c, ResolvedVar { name: "c", sort: BigRatSort, is_global_ref: false })]), Call(In 11:15-22 of tests/bignum.egg: (>> a 1), Primitive(SpecializedPrimitive { primitive: Prim(>>), input: [BigIntSort, I64Sort], output: BigIntSort }), [Var(In 11:19-19 of tests/bignum.egg: a, ResolvedVar { name: "a", sort: BigIntSort, is_global_ref: false }), Lit(In 11:21-21 of tests/bignum.egg: 1, Int(1))])), Eq(In 12:2-23 of tests/bignum.egg: (= (denom c) (>> b 1)), Call(In 12:5-13 of tests/bignum.egg: (denom c), Primitive(SpecializedPrimitive { primitive: Prim(denom), input: [BigRatSort], output: BigIntSort }), [Var(In 12:12-12 of tests/bignum.egg: c, ResolvedVar { name: "c", sort: BigRatSort, is_global_ref: false })]), Call(In 12:15-22 of tests/bignum.egg: (>> b 1), Primitive(SpecializedPrimitive { primitive: Prim(>>), input: [BigIntSort, I64Sort], output: BigIntSort }), [Var(In 12:19-19 of tests/bignum.egg: b, ResolvedVar { name: "b", sort: BigIntSort, is_global_ref: false }), Lit(In 12:21-21 of tests/bignum.egg: 1, Int(1))]))].
```