### PR TITLE
Add subsumption support

### DIFF
--- a/egglog-bridge/examples/ac.rs
+++ b/egglog-bridge/examples/ac.rs
@@ -1,4 +1,4 @@
-use egglog_bridge::{define_rule, ColumnTy, DefaultVal, EGraph, MergeFn};
+use egglog_bridge::{define_rule, ColumnTy, DefaultVal, EGraph, FunctionConfig, MergeFn};
 
 use mimalloc::MiMalloc;
 
@@ -28,18 +28,20 @@ fn main() {
         let start = web_time::Instant::now();
         let mut egraph = EGraph::default();
         let int_prim = egraph.primitives_mut().get_ty::<i64>();
-        let num_table = egraph.add_table(
-            vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "num",
-        );
-        let add_table = egraph.add_table(
-            vec![ColumnTy::Id; 3],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "add",
-        );
+        let num_table = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "num".into(),
+            can_subsume: true,
+        });
+        let add_table = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id; 3],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "add".into(),
+            can_subsume: true,
+        });
 
         let add_comm = define_rule! {
             [egraph] ((-> (add_table x y) id))

--- a/egglog-bridge/examples/ac.rs
+++ b/egglog-bridge/examples/ac.rs
@@ -33,14 +33,14 @@ fn main() {
             default: DefaultVal::FreshId,
             merge: MergeFn::UnionId,
             name: "num".into(),
-            can_subsume: true,
+            can_subsume: false,
         });
         let add_table = egraph.add_table(FunctionConfig {
             schema: vec![ColumnTy::Id; 3],
             default: DefaultVal::FreshId,
             merge: MergeFn::UnionId,
             name: "add".into(),
-            can_subsume: true,
+            can_subsume: false,
         });
 
         let add_comm = define_rule! {

--- a/egglog-bridge/examples/ac_tracing.rs
+++ b/egglog-bridge/examples/ac_tracing.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use egglog_bridge::{define_rule, ColumnTy, DefaultVal, EGraph, MergeFn};
+use egglog_bridge::{define_rule, ColumnTy, DefaultVal, EGraph, FunctionConfig, MergeFn};
 
 fn main() {
     const N: usize = 12;
@@ -14,18 +14,20 @@ fn main() {
     }
     let mut egraph = EGraph::with_tracing();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
-    let num_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "num",
-    );
-    let add_table = egraph.add_table(
-        vec![ColumnTy::Id; 3],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "add",
-    );
+    let num_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "num".into(),
+        can_subsume: true,
+    });
+    let add_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id; 3],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "add".into(),
+        can_subsume: true,
+    });
 
     let add_comm = define_rule! {
         [egraph] ((-> (add_table x y) id))

--- a/egglog-bridge/examples/ac_tracing.rs
+++ b/egglog-bridge/examples/ac_tracing.rs
@@ -19,14 +19,14 @@ fn main() {
         default: DefaultVal::FreshId,
         merge: MergeFn::UnionId,
         name: "num".into(),
-        can_subsume: true,
+        can_subsume: false,
     });
     let add_table = egraph.add_table(FunctionConfig {
         schema: vec![ColumnTy::Id; 3],
         default: DefaultVal::FreshId,
         merge: MergeFn::UnionId,
         name: "add".into(),
-        can_subsume: true,
+        can_subsume: false,
     });
 
     let add_comm = define_rule! {

--- a/egglog-bridge/examples/math.rs
+++ b/egglog-bridge/examples/math.rs
@@ -1,4 +1,6 @@
-use egglog_bridge::{add_expressions, define_rule, ColumnTy, DefaultVal, EGraph, MergeFn};
+use egglog_bridge::{
+    add_expressions, define_rule, ColumnTy, DefaultVal, EGraph, FunctionConfig, MergeFn,
+};
 use mimalloc::MiMalloc;
 use num_rational::Rational64;
 use web_time::Instant;
@@ -31,85 +33,107 @@ fn main() {
         let rational_ty = egraph.primitives_mut().register_type::<Rational64>();
         let string_ty = egraph.primitives_mut().register_type::<&'static str>();
         // tables
-        let diff = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "diff",
-        );
-        let integral = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "integral",
-        );
-        let add = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "add",
-        );
-        let sub = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "sub",
-        );
-        let mul = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "mul",
-        );
-        let div = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "div",
-        );
-        let pow = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "pow",
-        );
+        let diff = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "diff".into(),
+            can_subsume: false,
+        });
+        let integral = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "integral".into(),
+            can_subsume: false,
+        });
 
-        let ln = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "ln",
-        );
-        let sqrt = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "sqrt",
-        );
-        let sin = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "sin",
-        );
-        let cos = egraph.add_table(
-            vec![ColumnTy::Id, ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "cos",
-        );
-        let rat = egraph.add_table(
-            vec![ColumnTy::Primitive(rational_ty), ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "ret",
-        );
-        let var = egraph.add_table(
-            vec![ColumnTy::Primitive(string_ty), ColumnTy::Id],
-            DefaultVal::FreshId,
-            MergeFn::UnionId,
-            "var",
-        );
+        let add = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "add".into(),
+            can_subsume: false,
+        });
+        let sub = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "sub".into(),
+            can_subsume: false,
+        });
+
+        let mul = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "mul".into(),
+            can_subsume: false,
+        });
+
+        let div = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "div".into(),
+            can_subsume: false,
+        });
+
+        let pow = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "pow".into(),
+            can_subsume: false,
+        });
+
+        let ln = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "ln".into(),
+            can_subsume: false,
+        });
+
+        let sqrt = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "sqrt".into(),
+            can_subsume: false,
+        });
+
+        let sin = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "sin".into(),
+            can_subsume: false,
+        });
+
+        let cos = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Id, ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "cos".into(),
+            can_subsume: false,
+        });
+
+        let rat = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Primitive(rational_ty), ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "rat".into(),
+            can_subsume: false,
+        });
+
+        let var = egraph.add_table(FunctionConfig {
+            schema: vec![ColumnTy::Primitive(string_ty), ColumnTy::Id],
+            default: DefaultVal::FreshId,
+            merge: MergeFn::UnionId,
+            name: "var".into(),
+            can_subsume: false,
+        });
 
         let zero = egraph.primitive_constant(Rational64::new(0, 1));
         let one = egraph.primitive_constant(Rational64::new(1, 1));

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1327,7 +1327,7 @@ impl SchemaMath {
         } else {
             assert!(
                 !self.subsume,
-                "subsume flag be provided if subsumption is enabled"
+                "subsume flag must be provided if subsumption is enabled"
             );
         }
     }

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -378,14 +378,22 @@ impl RuleBuilder<'_> {
                 func_cols: entries.len(),
             }
         };
-        atom.resize_with(schema_math.table_columns(), || {
-            self.new_var(ColumnTy::Id).into()
-        });
-        if let Some(subsume_entry) = subsume_entry {
-            if schema_math.subsume {
-                atom[schema_math.subsume_col()] = subsume_entry;
-            }
-        }
+        schema_math.write_table_row(
+            &mut atom,
+            RowVals {
+                timestamp: self.new_var(ColumnTy::Id).into(),
+                proof: self
+                    .egraph
+                    .tracing
+                    .then(|| self.new_var(ColumnTy::Id).into()),
+                subsume: if schema_math.subsume {
+                    Some(subsume_entry.unwrap_or_else(|| self.new_var(ColumnTy::Id).into()))
+                } else {
+                    None
+                },
+                ret_val: None,
+            },
+        );
         if self.egraph.tracing {
             let proof_var = atom[schema_math.proof_id_col()].var();
             self.proof_builder.add_lhs(entries, proof_var);

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 
 use crate::syntax::{Binding, Entry, Statement, TermFragment};
 use crate::term_proof_dag::PrimitiveConstant;
+use crate::SchemaMath;
 use crate::{
     proof_spec::{ProofBuilder, RebuildVars},
     ColumnTy, DefaultVal, EGraph, FunctionId, Result, RuleId, RuleInfo, Timestamp,
@@ -354,10 +355,15 @@ impl RuleBuilder<'_> {
             self.proof_builder.add_lhs(entries, proof_var);
             self.query.atom_proofs.push(proof_var);
             if let Some(func) = func {
+                let math = SchemaMath {
+                    tracing: true,
+                    subsume: false,
+                    func_cols: self.egraph.funcs[func].schema.len(),
+                };
                 // If we have a function, record its syntax as a LHS term.
                 let term = Arc::new(TermFragment::App(
                     func,
-                    entries[0..entries.len() - 1]
+                    entries[0..math.num_keys()]
                         .iter()
                         .map(|x| {
                             x.to_syntax(self.egraph)

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -14,7 +14,8 @@ use num_rational::Rational64;
 use numeric_id::NumericId;
 
 use crate::{
-    add_expressions, define_rule, ColumnTy, DefaultVal, EGraph, FunctionId, MergeFn, QueryEntry,
+    add_expressions, define_rule, ColumnTy, DefaultVal, EGraph, FunctionConfig, FunctionId,
+    MergeFn, QueryEntry,
 };
 
 #[test]
@@ -22,18 +23,20 @@ fn ac() {
     const N: usize = 5;
     let mut egraph = EGraph::default();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
-    let num_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "num",
-    );
-    let add_table = egraph.add_table(
-        vec![ColumnTy::Id; 3],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "add",
-    );
+    let num_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "num".into(),
+        can_subsume: false,
+    });
+    let add_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id; 3],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "add".into(),
+        can_subsume: false,
+    });
 
     let add_comm = define_rule! {
         [egraph] ((-> (add_table x y) id))
@@ -95,18 +98,20 @@ fn ac_tracing() {
     const N: usize = 5;
     let mut egraph = EGraph::with_tracing();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
-    let num_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "num",
-    );
-    let add_table = egraph.add_table(
-        vec![ColumnTy::Id; 3],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "add",
-    );
+    let num_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "num".into(),
+        can_subsume: false,
+    });
+    let add_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id; 3],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "add".into(),
+        can_subsume: false,
+    });
 
     let add_comm = define_rule! {
         [egraph] ((-> (add_table x y) id))
@@ -172,18 +177,20 @@ fn ac_fail() {
     egraph.primitives_mut().register_type::<i64>();
     let int_prim = egraph.primitives_mut().get_ty::<i64>();
     let one = egraph.primitive_constant(1i64);
-    let num_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "num",
-    );
-    let add_table = egraph.add_table(
-        vec![ColumnTy::Id; 3],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "add",
-    );
+    let num_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "num".into(),
+        can_subsume: false,
+    });
+    let add_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id; 3],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "add".into(),
+        can_subsume: false,
+    });
 
     let add_comm = define_rule! {
         [egraph] ((-> (add_table x y) id) (-> (num_table {one}) x))
@@ -256,85 +263,98 @@ fn math_test(mut egraph: EGraph) {
     let rational_ty = egraph.primitives_mut().register_type::<Rational64>();
     let string_ty = egraph.primitives_mut().register_type::<&'static str>();
     // tables
-    let diff = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "diff",
-    );
-    let integral = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "integral",
-    );
-    let add = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "add",
-    );
-    let sub = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "sub",
-    );
-    let mul = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "mul",
-    );
-    let div = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "div",
-    );
-    let pow = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "pow",
-    );
+    let diff = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "diff".into(),
+        can_subsume: false,
+    });
+    let integral = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "integral".into(),
+        can_subsume: false,
+    });
+    let add = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "add".into(),
+        can_subsume: false,
+    });
+    let sub = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "sub".into(),
+        can_subsume: false,
+    });
+    let mul = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "mul".into(),
+        can_subsume: false,
+    });
+    let div = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "div".into(),
+        can_subsume: false,
+    });
+    let pow = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "pow".into(),
+        can_subsume: false,
+    });
 
-    let ln = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "ln",
-    );
-    let sqrt = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "sqrt",
-    );
-    let sin = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "sin",
-    );
-    let cos = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "cos",
-    );
-    let rat = egraph.add_table(
-        vec![ColumnTy::Primitive(rational_ty), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "rat",
-    );
-    let var = egraph.add_table(
-        vec![ColumnTy::Primitive(string_ty), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "var",
-    );
+    let ln = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "ln".into(),
+        can_subsume: false,
+    });
+    let sqrt = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "sqrt".into(),
+        can_subsume: false,
+    });
+    let sin = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "sin".into(),
+        can_subsume: false,
+    });
+    let cos = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "cos".into(),
+        can_subsume: false,
+    });
+    let rat = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(rational_ty), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "rat".into(),
+        can_subsume: false,
+    });
+    let var = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(string_ty), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "var".into(),
+        can_subsume: false,
+    });
 
     let zero = egraph.primitive_constant(Rational64::new(0, 1));
     let one = egraph.primitive_constant(Rational64::new(1, 1));
@@ -583,24 +603,27 @@ fn container_test() {
     //  * Dumping/foreach functionality.
     let mut egraph = EGraph::default();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
-    let num_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "num",
-    );
-    let add_table = egraph.add_table(
-        vec![ColumnTy::Id; 3],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "add",
-    );
-    let vec_table = egraph.add_table(
-        vec![ColumnTy::Id; 2],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "vec",
-    );
+    let num_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "num".into(),
+        can_subsume: false,
+    });
+    let add_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id; 3],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "add".into(),
+        can_subsume: false,
+    });
+    let vec_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id; 2],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "vec".into(),
+        can_subsume: false,
+    });
     let int_add = egraph.register_external_func(make_external_func(|exec_state, args| {
         let [x, y] = args else { panic!() };
         let x: i64 = exec_state.prims().unwrap(*x);
@@ -745,12 +768,13 @@ fn rhs_only_rule() {
     let int_prim = egraph.primitives_mut().register_type::<i64>();
     let zero = egraph.primitives_mut().get(0i64);
     let one = egraph.primitives_mut().get(1i64);
-    let num_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "num",
-    );
+    let num_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "num".into(),
+        can_subsume: false,
+    });
     let add_data = {
         let zero = egraph.primitive_constant(0i64);
         let one = egraph.primitive_constant(1i64);
@@ -830,18 +854,19 @@ fn mergefn_arithmetic() {
 
     // Create a function with merge function (+ 1 (* old new))
     // This uses nested MergeFn::Primitive with external functions to build the complex merge function
-    let f_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Primitive(int_prim)],
-        DefaultVal::Fail,
-        MergeFn::Primitive(
+    let f_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Primitive(int_prim)],
+        default: DefaultVal::Fail,
+        merge: MergeFn::Primitive(
             add_func,
             vec![
                 MergeFn::Const(value_1),
                 MergeFn::Primitive(multiply_func, vec![MergeFn::Old, MergeFn::New]),
             ],
         ),
-        "f",
-    );
+        name: "f".into(),
+        can_subsume: false,
+    });
 
     let value_0 = egraph.primitive_constant(0i64);
     let value_1 = egraph.primitive_constant(1i64);
@@ -922,27 +947,29 @@ fn mergefn_nested_function() {
     let int_prim = egraph.primitives_mut().register_type::<i64>();
 
     // Create a function g that will be used in the merge function for f
-    let g_table = egraph.add_table(
-        vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "g",
-    );
+    let g_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Id, ColumnTy::Id, ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "g".into(),
+        can_subsume: false,
+    });
 
     // Create a function f whose merge function is (g (g new new) (g old old))
     // This uses nested MergeFn::Function to build the complex merge function
-    let f_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::Function(
+    let f_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::Function(
             g_table,
             vec![
                 MergeFn::Function(g_table, vec![MergeFn::New, MergeFn::New]),
                 MergeFn::Function(g_table, vec![MergeFn::Old, MergeFn::Old]),
             ],
         ),
-        "f",
-    );
+        name: "f".into(),
+        can_subsume: false,
+    });
 
     let value_1 = egraph.primitive_constant(1i64);
     let value_2 = egraph.primitive_constant(2i64);
@@ -1037,18 +1064,20 @@ fn constrain_prims_simple() {
     let mut egraph = EGraph::default();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
     let bool_prim = egraph.primitives_mut().register_type::<bool>();
-    let f_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "f",
-    );
-    let g_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "g",
-    );
+    let f_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "f".into(),
+        can_subsume: false,
+    });
+    let g_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "g".into(),
+        can_subsume: false,
+    });
 
     let is_even = egraph.register_external_func(core_relations::make_external_func(
         |state, vals| -> Option<Value> {
@@ -1113,18 +1142,20 @@ fn constrain_prims_abstract() {
     // (neg x) = (abs x) when adding to 'g'. This adds only -1 and 0 to g
     let mut egraph = EGraph::default();
     let int_prim = egraph.primitives_mut().register_type::<i64>();
-    let f_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "f",
-    );
-    let g_table = egraph.add_table(
-        vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
-        DefaultVal::FreshId,
-        MergeFn::UnionId,
-        "g",
-    );
+    let f_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "f".into(),
+        can_subsume: false,
+    });
+    let g_table = egraph.add_table(FunctionConfig {
+        schema: vec![ColumnTy::Primitive(int_prim), ColumnTy::Id],
+        default: DefaultVal::FreshId,
+        merge: MergeFn::UnionId,
+        name: "g".into(),
+        can_subsume: false,
+    });
 
     let neg = egraph.register_external_func(core_relations::make_external_func(
         |state, vals| -> Option<Value> {

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -928,7 +928,7 @@ fn mergefn_nested_function() {
         default: DefaultVal::FreshId,
         merge: MergeFn::UnionId,
         name: "g".into(),
-        can_subsume: false,
+        can_subsume: true,
     });
 
     // Create a function f whose merge function is (g (g new new) (g old old))
@@ -944,7 +944,7 @@ fn mergefn_nested_function() {
             ],
         ),
         name: "f".into(),
-        can_subsume: false,
+        can_subsume: true,
     });
 
     let value_1 = egraph.primitive_constant(1i64);

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -18,6 +18,13 @@ use crate::{
     MergeFn, QueryEntry,
 };
 
+/// Run a simple associativity/commutativity test. In addition to testing that the rules properly
+/// reassociate a nested sum, this test checks a proof of an arbitrary term in the database if
+/// `tracing` is true.
+///
+/// The `can_subsume` argument is only used to enable subsumption on the underlying tables created
+/// during this test, and exercise the different column handling caused by enabling subsumption.
+/// Subsumption itself is not used.
 fn ac_test(tracing: bool, can_subsume: bool) {
     const N: usize = 5;
     let mut egraph = if tracing {
@@ -220,6 +227,13 @@ fn math_tracing_subsume() {
     math_test(EGraph::with_tracing(), true)
 }
 
+/// Run a more complex benchmark from the egg and egglog test suite. The core of this test is to
+/// ensure that the test generates a set of tables of exactly the same
+/// size that the corresponding rules in egglog do in egglog's initial implementation.
+///
+/// As in `ac_test` the `can_subsume` argument is only used to enable subsumption on the underlying
+/// tables created during this test, and exercise the different column handling caused by enabling
+/// subsumption. Subsumption itself is not used.
 fn math_test(mut egraph: EGraph, can_subsume: bool) {
     const N: usize = 8;
     let rational_ty = egraph.primitives_mut().register_type::<Rational64>();


### PR DESCRIPTION
This change adds support for subsumption in `egglog-bridge`. The core idea is that, when a function is enabled for subsumption, we will add an extra non-key column to the underlying table in `core-relations` which is 0 or 1 depending on the status of the enode being subsumed. Calls to `subsume` will instantiate an e-node if it doesn't exist. Rebuilding propagates the "subsumption status" of a row.

A number of things were refactored here in order to make the subsumption implementation straightforward:

* Calls to `add_table` now take a struct `FunctionConfig` that encapsulates all of the arguments needed to configure a function.
* A lot of the handling around non-key columns was based on ad-hoc math, with lots of expressions like `entries[n_args+1]=timestamp` and such. Adding yet another non-key column makes this even more brittle. To combat this code around which columns go where is now encapsulated in a `SchemaMath` type which tracks the location of proofs, timestamps, etc. based on the configuration of the egraph and the table.

Along with that, there are a few methods in `RuleBuilder` that now have the main implementation in a method that takes a `QueryEntry` to be used as the subsumption value. This allows us to constrain or use different subsumption variables throughout the rule building process, though I'm open to ways to structure it better.