### PR TITLE
better support for empty keys in SortedWritesTable

### DIFF
--- a/core-relations/src/table/tests.rs
+++ b/core-relations/src/table/tests.rs
@@ -28,6 +28,26 @@ fn dump_subset(table: &impl Table, subset: SubsetRef) -> Vec<(RowId, Vec<Value>)
 }
 
 #[test]
+fn empty_key() {
+    empty_execution_state!(e);
+    let mut table = fill_table(
+        vec![vec![v(1), v(2)], vec![v(2), v(3)]],
+        0,
+        None,
+        |_, new| Some(new.to_vec()),
+    );
+    let row = table.get_row(&[]).expect("empty key should be present");
+    assert_eq!(*row.vals, vec![v(2), v(3)]);
+    table.new_buffer().stage_remove(&[]);
+    table.merge(&mut e);
+    assert!(table.get_row(&[]).is_none(), "empty key should be removed");
+    table.new_buffer().stage_insert(&[v(1), v(2)]);
+    table.merge(&mut e);
+    let row = table.get_row(&[]).expect("empty key should be present");
+    assert_eq!(*row.vals, vec![v(1), v(2)]);
+}
+
+#[test]
 fn insert_scan() {
     let table = fill_table(
         vec![


### PR DESCRIPTION
The key issue here is that `RowBuffer` does not support arity 0. I looked back over the `RowBuffer` code and I think that modifying it to support arity 0 would be pretty disruptive. In particular there are a few methods that return iterators from combinators and replacing `RowBuffer` with an enum or similar branching logic would require that we move from combinators to custom iterator types. This is analogous to memory allocators needing special handling for 0-sized types in Rust.

Instead this change just locally replaces `RowBuffer` with an enum when processing deletion requests.