### PR TITLE
Merge function bugfixes

### DIFF
--- a/core-relations/src/table_shortcuts.rs
+++ b/core-relations/src/table_shortcuts.rs
@@ -14,11 +14,8 @@ macro_rules! empty_execution_state {
     ($es:ident) => {
         let mut __db = $crate::free_join::Database::default();
         let __pv = $crate::action::PredictedVals::default();
-        let mut $es = $crate::action::ExecutionState {
-            db: __db.read_only_view(),
-            predicted: &__pv,
-            buffers: Default::default(),
-        };
+        let mut $es =
+            $crate::action::ExecutionState::new(&__pv, __db.read_only_view(), Default::default());
     };
 }
 

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1001,11 +1001,7 @@ impl MergeFn {
             let ret_val = {
                 let cur = cur[schema_math.ret_val_col()];
                 let new = new[schema_math.ret_val_col()];
-                let out = if cur == new {
-                    cur
-                } else {
-                    resolved.run(state, cur, new, timestamp)
-                };
+                let out = resolved.run(state, cur, new, timestamp);
                 changed |= cur != out;
                 out
             };
@@ -1173,6 +1169,11 @@ impl ResolvedMergeFn {
                 default,
                 panic,
             } => {
+                // see github.com/egraphs-good/egglog/pull/287
+                if cur == new {
+                    return cur;
+                }
+
                 let args = args
                     .iter()
                     .map(|arg| arg.run(state, cur, new, ts))

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1093,6 +1093,10 @@ impl MergeFn {
     }
 }
 
+/// This enum is taking the place of a
+/// `Box<dyn Fn(&mut ExecutionState, Value, Value, Value) -> Value + Send + Sync>`
+/// to avoid extra boxes. It stores the data needed to run a `MergeFn` without
+/// holding onto any references, so it can be `move`d inside the `core_relations::MergeFn`.
 enum ResolvedMergeFn {
     Const(Value),
     Old,

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1001,7 +1001,11 @@ impl MergeFn {
             let ret_val = {
                 let cur = cur[schema_math.ret_val_col()];
                 let new = new[schema_math.ret_val_col()];
-                let out = resolved.run(state, cur, new, timestamp);
+                let out = if cur == new {
+                    cur
+                } else {
+                    resolved.run(state, cur, new, timestamp)
+                };
                 changed |= cur != out;
                 out
             };


### PR DESCRIPTION
Adds `ExecutionState::changed` and refactors `MergeFn::to_callback`.

This fixes the `merge-saturate.egg` and `rw-analysis.egg` tests.