### PR TITLE
Create `Lookup` abstraction for other crates implementing `ExternalFunction`

### DIFF
--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1175,7 +1175,14 @@ impl ResolvedMergeFn {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// This is an intern-able struct that holds all the data needed
+/// to do a "table lookup" on an [`ExecutionState`], assuming that
+/// the [`FunctionId`] for the table is known ahead of time.
+///
+/// A "table lookup" is not a read-only operation. It will insert a row when
+/// the [`DefaultVal`] for the table is not [`DefaultVal::Fail`] and
+/// the `args` in [`Lookup::run`] are not already present in the table.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Lookup {
     table: TableId,
     table_math: SchemaMath,

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1203,6 +1203,7 @@ impl Lookup {
     }
 
     pub fn run(&self, state: &mut ExecutionState, args: &[Value]) -> Option<Value> {
+        assert!(!self.table_math.tracing, "proofs not supported yet");
         match self.default {
             Some(default) => {
                 let timestamp =


### PR DESCRIPTION
This PR factors out the logic from `MergeFn::Function` that we want to reuse for `unstable-fn`. However, I think that this abstraction is reasonable to expose even without `unstable-fn`, as it seems likely that future `egglog-experimental` primitives will want access to tables.