### PR TITLE
Proper panic behavior

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -150,7 +150,7 @@ impl Bindings {
         self.assert_invariant();
     }
 
-    fn take(&mut self, var: Variable) -> Option<Pooled<Vec<Value>>> {
+    pub(crate) fn take(&mut self, var: Variable) -> Option<Pooled<Vec<Value>>> {
         self.vars.take(var)
     }
 }
@@ -512,6 +512,44 @@ impl ExecutionState<'_> {
                 let table = &self.db.table_info[*table].table;
                 table.lookup_row_vectorized(mask, bindings, args, *dst_col, *dst_var);
             }
+
+            Instr::LookupOrCallExternal {
+                table: table_id,
+                table_key,
+                func,
+                func_args,
+                dst_col,
+                dst_var,
+            } => {
+                // Do two passes over the current vector. First, do a round of lookups. Then, for
+                // any offsets where the lookup failed, insert the default value.
+                let table = &self.db.table_info[*table_id].table;
+                let mut lookup_result = mask.clone();
+                table.lookup_row_vectorized(
+                    &mut lookup_result,
+                    bindings,
+                    table_key,
+                    *dst_col,
+                    *dst_var,
+                );
+                let mut to_call_func = lookup_result.clone();
+                to_call_func.symmetric_difference(mask);
+                if to_call_func.is_empty() {
+                    return;
+                }
+                // Call the given external function on all entries where the lookup failed.
+                self.db.external_funcs[*func].invoke_batch_assign(
+                    self,
+                    &mut to_call_func,
+                    bindings,
+                    func_args,
+                    *dst_var,
+                );
+                // Any value that is not set in mask_copy but is set in mask needs to be cleared.
+                // mask_copy is a subset of mask, so this is just symmetric_difference.
+                lookup_result.union(&to_call_func);
+                *mask = lookup_result;
+            }
             Instr::Insert { table, vals } => {
                 let pool = pool_set.get_pool::<Vec<Value>>().clone();
                 iter_entries!(pool, vals).for_each(|vals| {
@@ -597,6 +635,19 @@ pub(crate) enum Instr {
     Lookup {
         table: TableId,
         args: Vec<QueryEntry>,
+        dst_col: ColumnId,
+        dst_var: Variable,
+    },
+
+    /// Look up the given key in the table: if the value is not present in the given table, then
+    /// call the given external function with the given arguments. If the external function returns
+    /// a value, that value is returned in the given `dst_var`. If the lookup fails and the
+    /// external function does not return a value, then execution is halted.
+    LookupOrCallExternal {
+        table: TableId,
+        table_key: Vec<QueryEntry>,
+        func: ExternalFunctionId,
+        func_args: Vec<QueryEntry>,
         dst_col: ColumnId,
         dst_var: Variable,
     },

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -544,8 +544,8 @@ impl ExecutionState<'_> {
                     func_args,
                     *dst_var,
                 );
-                // Any value that is not set in mask_copy but is set in mask needs to be cleared.
-                // mask_copy is a subset of mask, so this is just symmetric_difference.
+                // The new mask should be the lanes where the lookup succeeded or where `func`
+                // succeeded.
                 lookup_result.union(&to_call_func);
                 *mask = lookup_result;
             }
@@ -620,6 +620,7 @@ impl ExecutionState<'_> {
                     args2,
                     *dst,
                 );
+                // The new mask should be the lanes where either `f1` or `f2` succeeded.
                 f1_result.union(&to_call_f2);
                 *mask = f1_result;
             }

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -187,7 +187,7 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
     /// rather than assigning all new values.
     ///
     /// *Panics* This method will panic if `out_var` doesn't already have an appropriately-sized
-    /// vector boudn in `bindings`.
+    /// vector bound in `bindings`.
     #[doc(hidden)]
     fn invoke_batch_assign(
         &self,

--- a/core-relations/src/query.rs
+++ b/core-relations/src/query.rs
@@ -470,7 +470,7 @@ impl RuleBuilder<'_, '_> {
     /// Look up the given key in the given table. If the lookup fails, then call the given external
     /// function with the given arguments. Bind the result to the returned variable. If the
     /// external function returns None (and the lookup fails) then the execution of the rule halts.
-    pub fn lookup_or_call_external(
+    pub fn lookup_with_fallback(
         &mut self,
         table: TableId,
         key: &[QueryEntry],
@@ -487,7 +487,7 @@ impl RuleBuilder<'_, '_> {
             .expect("table must be declared in the current database");
         self.validate_keys(table, table_info, key)?;
         let res = self.qb.new_var();
-        self.qb.instrs.push(Instr::LookupOrCallExternal {
+        self.qb.instrs.push(Instr::LookupWithFallback {
             table,
             table_key: key.to_vec(),
             func,

--- a/core-relations/src/query.rs
+++ b/core-relations/src/query.rs
@@ -500,6 +500,26 @@ impl RuleBuilder<'_, '_> {
         Ok(res)
     }
 
+    pub fn call_external_with_fallback(
+        &mut self,
+        f1: ExternalFunctionId,
+        args1: &[QueryEntry],
+        f2: ExternalFunctionId,
+        args2: &[QueryEntry],
+    ) -> Result<Variable, QueryError> {
+        let res = self.qb.new_var();
+        self.qb.instrs.push(Instr::ExternalWithFallback {
+            f1,
+            args1: args1.to_vec(),
+            f2,
+            args2: args2.to_vec(),
+            dst: res,
+        });
+        self.qb.mark_used(args1);
+        self.qb.mark_used(args2);
+        Ok(res)
+    }
+
     /// Continue execution iff the two arguments are equal.
     pub fn assert_eq(&mut self, l: QueryEntry, r: QueryEntry) {
         self.qb.instrs.push(Instr::AssertEq(l, r));

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -614,15 +614,12 @@ impl EGraph {
             self.db
                 .add_table(table, read_deps.iter().copied(), write_deps.iter().copied());
 
-        let panic_func = matches!(default, DefaultVal::Fail)
-            .then(|| self.new_panic(format!("lookup failed for {name}")));
         let res = self.funcs.push(FunctionInfo {
             table: table_id,
             schema: schema.clone(),
             incremental_rebuild_rules: Default::default(),
             nonincremental_rebuild_rule: RuleId::new(!0),
             default_val: default,
-            panic_func,
             can_subsume,
             name: name.into(),
         });
@@ -920,7 +917,6 @@ struct FunctionInfo {
     incremental_rebuild_rules: Vec<RuleId>,
     nonincremental_rebuild_rule: RuleId,
     default_val: DefaultVal,
-    panic_func: Option<ExternalFunctionId>,
     can_subsume: bool,
     name: Arc<str>,
 }

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -23,6 +23,7 @@ use core_relations::{
     Offset, PlanStrategy, PrimitiveId, Primitives, SortedWritesTable, TableId, TaggedRowBuffer,
     Value, WrappedTable,
 };
+use hashbrown::HashMap;
 use indexmap::{map::Entry, IndexMap, IndexSet};
 use log::info;
 use numeric_id::{define_id, DenseIdMap, DenseIdMapWithReuse, NumericId};
@@ -70,7 +71,12 @@ pub struct EGraph {
     rules: DenseIdMapWithReuse<RuleId, RuleInfo>,
     funcs: DenseIdMap<FunctionId, FunctionInfo>,
     panic_message: SideChannel<String>,
-    external_function_panic: ExternalFunctionId,
+    /// This is a cache of all the different panic messages that we may use while executing rules
+    /// against the EGraph. Oftentimes, these messages are generated dynamically: keeping this map
+    /// around allows us to cache external function ids with repeat panic messages and they can
+    /// also serve as a debugging tool in the case that the number of panic messages grows without
+    /// bound.
+    panic_funcs: HashMap<String, ExternalFunctionId>,
     proof_specs: DenseIdMap<ReasonSpecId, Arc<ProofReason>>,
     /// Side tables used to store proof information. We initialize these lazily
     /// as a proof object with a given number of parameters is added.
@@ -126,7 +132,7 @@ impl EGraph {
         // Start the timestamp counter at 1.
         db.inc_counter(ts_counter);
 
-        let mut egraph = Self {
+        Self {
             db,
             uf_table,
             id_counter,
@@ -135,16 +141,12 @@ impl EGraph {
             rules: Default::default(),
             funcs: Default::default(),
             panic_message: Default::default(),
-            // Placeholder
-            external_function_panic: ExternalFunctionId::new(!0),
+            panic_funcs: Default::default(),
             proof_specs: Default::default(),
             reason_tables: Default::default(),
             term_tables: Default::default(),
             tracing,
-        };
-        let external_function_panic = egraph.new_panic("primitive evaluation failed".to_string());
-        egraph.external_function_panic = external_function_panic;
-        egraph
+        }
     }
 
     fn next_ts(&self) -> Timestamp {
@@ -1316,8 +1318,10 @@ struct Panic(String, SideChannel<String>);
 impl EGraph {
     /// Create a new `ExternalFunction` that panics with the given message.
     pub fn new_panic(&mut self, message: String) -> ExternalFunctionId {
-        let panic = Panic(message, self.panic_message.clone());
-        self.db.add_external_function(panic)
+        *self.panic_funcs.entry(message.clone()).or_insert_with(|| {
+            let panic = Panic(message, self.panic_message.clone());
+            self.db.add_external_function(panic)
+        })
     }
 }
 

--- a/egglog-bridge/src/macros.rs
+++ b/egglog-bridge/src/macros.rs
@@ -37,7 +37,7 @@ macro_rules! parse_rhs_atom {
         {
             let mut vec = Vec::<$crate::QueryEntry>::new();
             $crate::parse_rhs_atom_args!($ebuilder, $builder, $func, vec, [$($args)*]);
-            $builder.lookup($func.into(), &vec)
+            $builder.lookup($func.into(), &vec, stringify!($func ($($args)*)))
         }
     }};
 }

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -550,9 +550,7 @@ impl RuleBuilder<'_> {
                 val: SUBSUMED,
                 ty: ColumnTy::Id,
             },
-            // Subsumption only happens with DefaultVal::FreshId, which will not use the panic
-            // message.
-            "this panic message should never show up (subsume)",
+            "subsumed a nonextestent row!",
         );
         let info = &self.egraph.funcs[func];
         let schema_math = SchemaMath {

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -725,7 +725,7 @@ impl RuleBuilder<'_> {
                     self.proof_builder.add_lhs(&entries, term_var);
                     Box::new(move |inner, rb| {
                         let dst_vars = inner.convert_all(&entries);
-                        let var = rb.lookup_or_call_external(
+                        let var = rb.lookup_with_fallback(
                             table,
                             &dst_vars,
                             ColumnId::from_usize(schema_math.ret_val_col()),
@@ -744,7 +744,7 @@ impl RuleBuilder<'_> {
                 } else {
                     Box::new(move |inner, rb| {
                         let dst_vars = inner.convert_all(&entries);
-                        let var = rb.lookup_or_call_external(
+                        let var = rb.lookup_with_fallback(
                             table,
                             &dst_vars,
                             ColumnId::from_usize(schema_math.ret_val_col()),

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -637,9 +637,11 @@ fn container_test() {
         let mut rb = egraph.new_rule("", true);
         let vec = rb.new_var(ColumnTy::Id);
         let vec_id = rb.new_var(ColumnTy::Id);
+        let last = rb.new_var(ColumnTy::Id);
         rb.query_table(vec_table, &[vec.into(), vec_id.into()], Some(false))
             .unwrap();
-        let last = rb.call_external_func(vec_last, &[vec.into()], ColumnTy::Id);
+        rb.query_prim(vec_last, &[vec.into(), last.into()], ColumnTy::Id)
+            .unwrap();
         let add_last_0 = rb.lookup(
             add_table,
             &[
@@ -661,9 +663,9 @@ fn container_test() {
             ],
         );
         let new_vec_1 =
-            rb.call_external_func(vec_push, &[vec.into(), add_last_0.into()], ColumnTy::Id);
+            rb.call_external_func(vec_push, &[vec.into(), add_last_0.into()], ColumnTy::Id, "");
         let new_vec_2 =
-            rb.call_external_func(vec_push, &[vec.into(), add_0_last.into()], ColumnTy::Id);
+            rb.call_external_func(vec_push, &[vec.into(), add_0_last.into()], ColumnTy::Id, "");
         rb.lookup(vec_table, &[new_vec_1.into()]);
         rb.lookup(vec_table, &[new_vec_2.into()]);
         rb.build()
@@ -690,6 +692,7 @@ fn container_test() {
             int_add,
             &[lhs_raw.into(), rhs_raw.into()],
             ColumnTy::Primitive(int_prim),
+            "",
         );
         let boxed = rb.lookup(num_table, &[evaled.into()]);
         rb.union(add_id.into(), boxed.into());
@@ -790,7 +793,7 @@ fn rhs_only_rule_only_runs_once() {
     }));
     let inc_counter_rule = {
         let mut rb = egraph.new_rule("", true);
-        rb.call_external_func(inc_counter_func, &[], ColumnTy::Id);
+        rb.call_external_func(inc_counter_func, &[], ColumnTy::Id, "");
         rb.build()
     };
 
@@ -1353,11 +1356,13 @@ fn primitive_failure_panics() {
             assert_odd,
             &[value_1.clone()],
             ColumnTy::Primitive(unit_prim),
+            "",
         );
         rb.call_external_func(
             assert_odd,
             &[value_2.clone()],
             ColumnTy::Primitive(unit_prim),
+            "",
         );
         rb.build()
     };

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -651,6 +651,7 @@ fn container_test() {
                     ty: ColumnTy::Primitive(int_prim),
                 },
             ],
+            "add_last_0",
         );
         let add_0_last = rb.lookup(
             add_table,
@@ -661,13 +662,14 @@ fn container_test() {
                 },
                 last.into(),
             ],
+            "add_0_last",
         );
         let new_vec_1 =
             rb.call_external_func(vec_push, &[vec.into(), add_last_0.into()], ColumnTy::Id, "");
         let new_vec_2 =
             rb.call_external_func(vec_push, &[vec.into(), add_0_last.into()], ColumnTy::Id, "");
-        rb.lookup(vec_table, &[new_vec_1.into()]);
-        rb.lookup(vec_table, &[new_vec_2.into()]);
+        rb.lookup(vec_table, &[new_vec_1.into()], "");
+        rb.lookup(vec_table, &[new_vec_2.into()], "");
         rb.build()
     };
 
@@ -694,7 +696,7 @@ fn container_test() {
             ColumnTy::Primitive(int_prim),
             "",
         );
-        let boxed = rb.lookup(num_table, &[evaled.into()]);
+        let boxed = rb.lookup(num_table, &[evaled.into()], "");
         rb.union(add_id.into(), boxed.into());
         rb.build()
     };
@@ -762,8 +764,8 @@ fn rhs_only_rule() {
         let zero = egraph.primitive_constant(0i64);
         let one = egraph.primitive_constant(1i64);
         let mut rb = egraph.new_rule("", true);
-        let _zero_id = rb.lookup(num_table, &[zero]);
-        let _one_id = rb.lookup(num_table, &[one]);
+        let _zero_id = rb.lookup(num_table, &[zero], "");
+        let _one_id = rb.lookup(num_table, &[one], "");
         rb.build()
     };
 
@@ -962,8 +964,8 @@ fn mergefn_nested_function() {
 
     let write_rule = {
         let mut rb = egraph.new_rule("write_rule", true);
-        rb.lookup(f_table, &[value_1.clone()]);
-        rb.lookup(f_table, &[value_2]);
+        rb.lookup(f_table, &[value_1.clone()], "");
+        rb.lookup(f_table, &[value_2], "");
         rb.build()
     };
 
@@ -1079,9 +1081,9 @@ fn constrain_prims_simple() {
     let value_true = egraph.primitive_constant(true);
     let write_f = {
         let mut rb = egraph.new_rule("write_f", true);
-        rb.lookup(f_table, &[value_1.clone()]);
-        rb.lookup(f_table, &[value_2.clone()]);
-        rb.lookup(f_table, &[value_3.clone()]);
+        rb.lookup(f_table, &[value_1.clone()], "");
+        rb.lookup(f_table, &[value_2.clone()], "");
+        rb.lookup(f_table, &[value_3.clone()], "");
         rb.build()
     };
 
@@ -1165,9 +1167,9 @@ fn constrain_prims_abstract() {
     let value_1 = egraph.primitive_constant(1i64);
     let write_f = {
         let mut rb = egraph.new_rule("write_f", true);
-        rb.lookup(f_table, &[value_n1.clone()]);
-        rb.lookup(f_table, &[value_0.clone()]);
-        rb.lookup(f_table, &[value_1.clone()]);
+        rb.lookup(f_table, &[value_n1.clone()], "");
+        rb.lookup(f_table, &[value_0.clone()], "");
+        rb.lookup(f_table, &[value_1.clone()], "");
         rb.build()
     };
 
@@ -1239,8 +1241,8 @@ fn basic_subsumption() {
     let value_3 = egraph.primitive_constant(3i64);
     let write_f = {
         let mut rb = egraph.new_rule("write_f", true);
-        rb.lookup(f_table, &[value_1.clone()]);
-        rb.lookup(f_table, &[value_2.clone()]);
+        rb.lookup(f_table, &[value_1.clone()], "");
+        rb.lookup(f_table, &[value_2.clone()], "");
         rb.build()
     };
 
@@ -1314,14 +1316,14 @@ fn lookup_failure_panics() {
 
     let lookup_success = {
         let mut rb = egraph.new_rule("lookup_success", true);
-        rb.lookup(f, &[value_1.clone()]);
+        rb.lookup(f, &[value_1.clone()], "");
         rb.build()
     };
     egraph.run_rules(&[lookup_success]).unwrap();
 
     let lookup_failure = {
         let mut rb = egraph.new_rule("lookup_fail", true);
-        rb.lookup(f, &[value_3.clone()]);
+        rb.lookup(f, &[value_3.clone()], "");
         rb.build()
     };
     egraph.run_rules(&[lookup_failure]).err().unwrap();


### PR DESCRIPTION
This PR wires in correct panic behavior for egglog constructs:

* Lookups on non-constructor functions without a specified default value should panic.
* Primitives that fail on the RHS of a rule should panic.

The main strategy here is to add new instructions to `core-relations` that run an external function on the "else branch" of a lookup or external function call.