### PR TITLE
Correct cloning for indexes during database clones

### DIFF
--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -234,6 +234,15 @@ impl<K, V> Default for IdVec<K, V> {
     }
 }
 
+impl<K, V: Clone> Clone for IdVec<K, V> {
+    fn clone(&self) -> Self {
+        IdVec {
+            data: self.data.clone(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
 /// Like a [`DenseIdMap`], but supports freeing (and reusing) slots.
 #[derive(Clone)]
 pub struct DenseIdMapWithReuse<K, V> {


### PR DESCRIPTION
PR is pretty straightforward. Let me know what you think of the caveat I added to the BufferedVec type in hash_index/mod.rs. That code is pretty local to this module (`Pooled` is the only reason it's even `pub(crate)`), but it's the only part that's a little subtle.