### PR TITLE
Only report changes in `merge` if tuples were added.

### DIFF
--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -439,7 +439,8 @@ impl Database {
         self.counters.read(counter)
     }
 
-    /// A helper for merging all pending updates. Used to write to the database after updates have been staged.
+    /// A helper for merging all pending updates. Used to write to the database after updates have
+    /// been staged. Returns true if any tuples were added.
     ///
     /// Exposed for testing purposes.
     ///
@@ -482,7 +483,7 @@ impl Database {
                         .par_iter_mut()
                         .map(|(_, (info, buffers))| {
                             let mut es = ExecutionState::new(&predicted, db, mem::take(buffers));
-                            info.as_mut().unwrap().table.merge(&mut es) || es.changed
+                            info.as_mut().unwrap().table.merge(&mut es).added || es.changed
                         })
                         .max()
                         .unwrap_or(false)
@@ -491,7 +492,7 @@ impl Database {
                         .iter_mut()
                         .map(|(_, (info, buffers))| {
                             let mut es = ExecutionState::new(&predicted, db, mem::take(buffers));
-                            info.as_mut().unwrap().table.merge(&mut es) || es.changed
+                            info.as_mut().unwrap().table.merge(&mut es).added || es.changed
                         })
                         .max()
                         .unwrap_or(false)

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -35,6 +35,7 @@ pub use query::{QueryBuilder, QueryError, RuleBuilder, RuleSet, RuleSetBuilder};
 pub use row_buffer::TaggedRowBuffer;
 pub use table::{MergeFn, SortedWritesTable};
 pub use table_spec::{
-    ColumnId, Constraint, Offset, Rebuilder, Row, Table, TableSpec, TableVersion, WrappedTable,
+    ColumnId, Constraint, Offset, Rebuilder, Row, Table, TableChange, TableSpec, TableVersion,
+    WrappedTable,
 };
 pub use uf::{DisplacedTable, DisplacedTableWithProvenance, ProofReason, ProofStep};

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -33,7 +33,7 @@ use crate::{
         ColumnId, Constraint, Generation, MutationBuffer, Offset, Row, Table, TableSpec,
         TableVersion,
     },
-    Pooled, TableId,
+    Pooled, TableChange, TableId,
 };
 
 mod rebuild;
@@ -495,12 +495,11 @@ impl Table for SortedWritesTable {
         })
     }
 
-    fn merge(&mut self, exec_state: &mut ExecutionState) -> bool {
-        let mut changed = false;
-        changed |= self.do_delete();
-        changed |= self.do_insert(exec_state);
+    fn merge(&mut self, exec_state: &mut ExecutionState) -> TableChange {
+        let removed = self.do_delete();
+        let added = self.do_insert(exec_state);
         self.maybe_rehash();
-        changed
+        TableChange { removed, added }
     }
 
     fn get_row(&self, key: &[Value]) -> Option<Row> {

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -81,6 +81,15 @@ impl TableSpec {
     }
 }
 
+/// A summary of the kinds of changes that a table underwent after a merge operation.
+#[derive(Eq, PartialEq, Copy, Clone)]
+pub struct TableChange {
+    /// Whether or not rows were added to the table.
+    pub added: bool,
+    /// Whether or not rows were removed from the table.
+    pub removed: bool,
+}
+
 /// A constraint on the values within a row.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Constraint {
@@ -307,7 +316,7 @@ pub trait Table: Any + Send + Sync {
 
     /// Merge any updates to the table, and potentially update the generation for
     /// the table.
-    fn merge(&mut self, exec_state: &mut ExecutionState) -> bool;
+    fn merge(&mut self, exec_state: &mut ExecutionState) -> TableChange;
 
     /// Create a new buffer for staging mutations on this table.
     fn new_buffer(&self) -> Box<dyn MutationBuffer>;


### PR DESCRIPTION
This change fixes the `repro-new-backend-delete` test.