### PR TITLE
Fix hanging core-relations tests.

### DIFF
--- a/core-relations/Cargo.toml
+++ b/core-relations/Cargo.toml
@@ -31,6 +31,7 @@ dyn-clone = "1.0.17"
 [dev-dependencies]
 once_cell = "1.20.2"
 divan = "0.1.15"
+mimalloc = "0.1"
 
 [[bench]]
 name = "writes"

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -656,7 +656,6 @@ fn get_index_from_tableinfo(table_info: &TableInfo, cols: &[ColumnId]) -> HashIn
                 TupleIndex::new(cols.len()),
             )))
         })
-        .value()
         .clone();
     let ix = index.read();
     if ix.needs_refresh(table_info.table.as_ref()) {
@@ -687,5 +686,5 @@ fn get_column_index_from_tableinfo(table_info: &TableInfo, col: ColumnId) -> Has
         let mut ix = index.lock();
         ix.refresh(table_info.table.as_ref());
     }
-    index.clone()
+    index
 }

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -647,31 +647,40 @@ impl Drop for Database {
 /// This is in a separate function to allow us to reuse it while already
 /// borrowing a `TableInfo`.
 fn get_index_from_tableinfo(table_info: &TableInfo, cols: &[ColumnId]) -> HashIndex {
-    let guard = table_info.indexes.entry(cols.into()).or_insert_with(|| {
-        Arc::new(ReadOptimizedLock::new(Index::new(
-            cols.to_vec(),
-            TupleIndex::new(cols.len()),
-        )))
-    });
-    let ix = guard.value().read();
+    let index: Arc<_> = table_info
+        .indexes
+        .entry(cols.into())
+        .or_insert_with(|| {
+            Arc::new(ReadOptimizedLock::new(Index::new(
+                cols.to_vec(),
+                TupleIndex::new(cols.len()),
+            )))
+        })
+        .value()
+        .clone();
+    let ix = index.read();
     if ix.needs_refresh(table_info.table.as_ref()) {
         mem::drop(ix);
-        let mut ix = guard.value().lock();
+        let mut ix = index.lock();
         ix.refresh(table_info.table.as_ref());
     }
-    guard.value().clone()
+    index
 }
 
 /// The core logic behind getting and updating a column index.
 ///
 /// This is the single-column analog to [`get_index_from_tableinfo`].
 fn get_column_index_from_tableinfo(table_info: &TableInfo, col: ColumnId) -> HashColumnIndex {
-    let index = table_info.column_indexes.entry(col).or_insert_with(|| {
-        Arc::new(ReadOptimizedLock::new(Index::new(
-            vec![col],
-            ColumnIndex::new(),
-        )))
-    });
+    let index: Arc<_> = table_info
+        .column_indexes
+        .entry(col)
+        .or_insert_with(|| {
+            Arc::new(ReadOptimizedLock::new(Index::new(
+                vec![col],
+                ColumnIndex::new(),
+            )))
+        })
+        .clone();
     let ix = index.read();
     if ix.needs_refresh(table_info.table.as_ref()) {
         mem::drop(ix);

--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -316,7 +316,7 @@ impl IndexBase for ColumnIndex {
 /// lock, this can cause a deadlock. We saw this in the tests for this crate. The relevant lock
 /// are those around individual indexes stored in the database-level index cache.
 fn run_in_thread_pool_and_block<'a>(pool: &rayon::ThreadPool, f: impl FnMut() + Send + 'a) {
-    // NB: We don't need the heap allocations here. But we are aonly calling this function if
+    // NB: We don't need the heap allocations here. But we are only calling this function if
     // we are about to do a bunch of work, so clarify is probably going to be better than (even
     // more) unsafe code.
 

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -19,6 +19,11 @@ use crate::{
     PlanStrategy,
 };
 
+/// On MacOs the system allocator is vulenrable to contention, causing tests to execute quite
+/// slowly without mimalloc.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[test]
 fn basic_query() {
     let MathEgraph {


### PR DESCRIPTION
Described this more in slack. There were two issues I found when looking through backtraces of hanging tests:

1. Concurrent calls into the allocator during `SortedWritesTable::merge` were causing things to slow way down. To fix this, we add `MiMalloc`. We may want to gate this behind specific platforms in a future change.
2. We were accidentally holding onto a dashmap lock during the index cache lookup code. This may have caused a deadlock (rayon calls itself recursively, but the index refresh code that takes up most of the accidental critical section actually has its own thread pool), but at the very least it probably forced a lot of parallel code to convoy in a very slow way.

Thanks to @yihozhang for finding the connection with the index cache. 