### PR TITLE
Add timing information

### DIFF
--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -188,6 +188,7 @@ impl Database {
         let preds = with_pool_set(|ps| ps.get::<PredictedVals>());
         let index_cache = IndexCache::default();
 
+        let search_and_apply_timer = Instant::now();
         let rule_reports = DashMap::default();
         if do_parallel() {
             self.update_cached_indexes();
@@ -255,6 +256,7 @@ impl Database {
                 Default::default(),
             ));
         }
+        let search_and_apply_time = search_and_apply_timer.elapsed();
 
         let merge_timer = Instant::now();
         let changed = self.merge_all();
@@ -263,6 +265,7 @@ impl Database {
         RuleSetReport {
             changed,
             rule_reports,
+            search_and_apply_time,
             merge_time,
         }
     }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -420,7 +420,7 @@ impl<'a> JoinState<'a> {
             table: &WrappedTableRef,
         ) -> Subset {
             let sub = table.refine_live(sub);
-            table.refine(sub, &constraints)
+            table.refine(sub, constraints)
         }
 
         match &plan.stages[cur] {

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -167,6 +167,7 @@ impl Database {
             }
         });
     }
+
     pub fn run_rule_set(&mut self, rule_set: &RuleSet) -> bool {
         fn do_parallel() -> bool {
             #[cfg(debug_assertions)]

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -415,9 +415,9 @@ impl Database {
         let table = &table_info.table;
         if let Some(c) = c {
             if let Some(sub) = table.fast_subset(&c) {
-                // In the case a the constraint can be computed quickly,
+                // In the case where a the constraint can be computed quickly,
                 // we do not filter for staleness, which may over-approximate.
-                return sub.size();
+                sub.size()
             } else {
                 table.refine_one(table.refine_live(table.all()), &c).size()
             }

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -11,6 +11,7 @@ use concurrency::ReadOptimizedLock;
 use numeric_id::{define_id, DenseIdMap, DenseIdMapWithReuse, NumericId};
 use rayon::prelude::*;
 use smallvec::SmallVec;
+use web_time::Duration;
 
 use crate::{
     action::{
@@ -257,6 +258,18 @@ impl Counters {
         // NB: we may want to experiment with Ordering::Relaxed here.
         self.0[ctr].fetch_add(1, Ordering::Release)
     }
+}
+
+#[derive(Debug, Default)]
+pub struct RuleSetReport {
+    pub changed: bool,
+    pub rule_reports: DashMap<String, RuleReport>,
+    pub merge_time: Duration,
+}
+
+#[derive(Debug)]
+pub struct RuleReport {
+    pub search_and_apply_time: Duration,
 }
 
 /// A collection of tables and indexes over them.

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -271,6 +271,7 @@ pub struct RuleSetReport {
 #[derive(Debug)]
 pub struct RuleReport {
     pub search_and_apply_time: Duration,
+    pub num_matches: usize,
 }
 
 /// A collection of tables and indexes over them.

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -264,6 +264,7 @@ impl Counters {
 pub struct RuleSetReport {
     pub changed: bool,
     pub rule_reports: DashMap<String, RuleReport>,
+    pub search_and_apply_time: Duration,
     pub merge_time: Duration,
 }
 

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -25,7 +25,7 @@ pub use common::Value;
 pub use containers::{Container, ContainerId, Containers};
 pub use free_join::{
     make_external_func, plan::PlanStrategy, CounterId, Database, ExternalFunction,
-    ExternalFunctionId, TableId, Variable,
+    ExternalFunctionId, RuleReport, RuleSetReport, TableId, Variable,
 };
 pub use hash_index::TupleIndex;
 pub use offsets::{OffsetRange, RowId, Subset, SubsetRef};

--- a/core-relations/src/primitives/mod.rs
+++ b/core-relations/src/primitives/mod.rs
@@ -70,8 +70,7 @@ impl Primitives {
 
     /// Get the [`PrimitiveId`] for the given primitive type id.
     pub fn get_ty_by_id(&self, id: TypeId) -> PrimitiveId {
-        self.type_ids
-            .intern(&id)
+        self.type_ids.intern(&id)
     }
 
     /// Get a [`Value`] representing the given primitive `p`.

--- a/core-relations/src/query.rs
+++ b/core-relations/src/query.rs
@@ -24,7 +24,14 @@ use crate::{
 /// See [`Database::new_rule_set`] for more information.
 #[derive(Default)]
 pub struct RuleSet {
-    pub(crate) plans: Vec<(Plan, String /* description */)>,
+    /// The contents of the queries (i.e. the LHS of the rules) for each rule in the set, along
+    /// with a description of the rule.
+    ///
+    /// The action here is used to map between rule descriptions and ActionIds. The current
+    /// accounting logic assumes that rules and actions stand in a bijection. If we relaxed that
+    /// later on, most of the core logic would still work but the accounting logic could get more
+    /// complex.
+    pub(crate) plans: Vec<(Plan, String /* description */, ActionId)>,
     pub(crate) actions: DenseIdMap<ActionId, Pooled<Vec<Instr>>>,
 }
 
@@ -281,7 +288,11 @@ impl RuleBuilder<'_, '_> {
         // Plan the query
         let plan = self.qb.rsb.db.plan_query(self.qb.query);
         // Add it to the ruleset.
-        self.qb.rsb.rule_set.plans.push((plan, desc.into()));
+        self.qb
+            .rsb
+            .rule_set
+            .plans
+            .push((plan, desc.into(), action_id));
     }
 
     /// Return a variable containing the result of looking up the specified

--- a/core-relations/src/table/mod.rs
+++ b/core-relations/src/table/mod.rs
@@ -412,67 +412,67 @@ impl Table for SortedWritesTable {
         match constraint {
             Constraint::Eq { .. } => None,
             Constraint::EqConst { col, val } => {
-                        if col == &sort_by {
-                            match self.binary_search_sort_val(*val) {
-                                Ok((found, bound)) => Some(Subset::Dense(OffsetRange::new(found, bound))),
-                                Err(_) => Some(Subset::empty()),
-                            }
-                        } else {
-                            None
-                        }
+                if col == &sort_by {
+                    match self.binary_search_sort_val(*val) {
+                        Ok((found, bound)) => Some(Subset::Dense(OffsetRange::new(found, bound))),
+                        Err(_) => Some(Subset::empty()),
                     }
+                } else {
+                    None
+                }
+            }
             Constraint::LtConst { col, val } => {
-                        if col == &sort_by {
-                            match self.binary_search_sort_val(*val) {
-                                Ok((found, _)) => {
-                                    Some(Subset::Dense(OffsetRange::new(RowId::new(0), found)))
-                                }
-                                Err(next) => Some(Subset::Dense(OffsetRange::new(RowId::new(0), next))),
-                            }
-                        } else {
-                            None
+                if col == &sort_by {
+                    match self.binary_search_sort_val(*val) {
+                        Ok((found, _)) => {
+                            Some(Subset::Dense(OffsetRange::new(RowId::new(0), found)))
                         }
+                        Err(next) => Some(Subset::Dense(OffsetRange::new(RowId::new(0), next))),
                     }
+                } else {
+                    None
+                }
+            }
             Constraint::GtConst { col, val } => {
-                        if col == &sort_by {
-                            match self.binary_search_sort_val(*val) {
-                                Ok((_, bound)) => {
-                                    Some(Subset::Dense(OffsetRange::new(bound, self.data.next_row())))
-                                }
-                                Err(next) => {
-                                    Some(Subset::Dense(OffsetRange::new(next, self.data.next_row())))
-                                }
-                            }
-                        } else {
-                            None
+                if col == &sort_by {
+                    match self.binary_search_sort_val(*val) {
+                        Ok((_, bound)) => {
+                            Some(Subset::Dense(OffsetRange::new(bound, self.data.next_row())))
+                        }
+                        Err(next) => {
+                            Some(Subset::Dense(OffsetRange::new(next, self.data.next_row())))
                         }
                     }
+                } else {
+                    None
+                }
+            }
             Constraint::LeConst { col, val } => {
-                        if col == &sort_by {
-                            match self.binary_search_sort_val(*val) {
-                                Ok((_, bound)) => {
-                                    Some(Subset::Dense(OffsetRange::new(RowId::new(0), bound)))
-                                }
-                                Err(next) => Some(Subset::Dense(OffsetRange::new(RowId::new(0), next))),
-                            }
-                        } else {
-                            None
+                if col == &sort_by {
+                    match self.binary_search_sort_val(*val) {
+                        Ok((_, bound)) => {
+                            Some(Subset::Dense(OffsetRange::new(RowId::new(0), bound)))
                         }
+                        Err(next) => Some(Subset::Dense(OffsetRange::new(RowId::new(0), next))),
                     }
+                } else {
+                    None
+                }
+            }
             Constraint::GeConst { col, val } => {
-                        if col == &sort_by {
-                            match self.binary_search_sort_val(*val) {
-                                Ok((found, _)) => {
-                                    Some(Subset::Dense(OffsetRange::new(found, self.data.next_row())))
-                                }
-                                Err(next) => {
-                                    Some(Subset::Dense(OffsetRange::new(next, self.data.next_row())))
-                                }
-                            }
-                        } else {
-                            None
+                if col == &sort_by {
+                    match self.binary_search_sort_val(*val) {
+                        Ok((found, _)) => {
+                            Some(Subset::Dense(OffsetRange::new(found, self.data.next_row())))
+                        }
+                        Err(next) => {
+                            Some(Subset::Dense(OffsetRange::new(next, self.data.next_row())))
                         }
                     }
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -248,7 +248,13 @@ pub trait Table: Any + Send + Sync {
     /// Filter a given subset of the table for the rows that are live
     fn refine_live(&self, subset: Subset) -> Subset {
         // NB: This relies on Value::stale() being strictly larger than any other value in the table.
-        self.refine_one(subset, &Constraint::LtConst { col: ColumnId::new_const(0), val: Value::stale() })
+        self.refine_one(
+            subset,
+            &Constraint::LtConst {
+                col: ColumnId::new_const(0),
+                val: Value::stale(),
+            },
+        )
     }
 
     /// Filter a given subset of the table for the rows matching the single constraint.

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -104,7 +104,7 @@ fn basic_query() {
     rules.build();
     let rule_set = rsb.build();
 
-    assert!(db.run_rule_set(&rule_set));
+    assert!(db.run_rule_set(&rule_set).changed);
     let num_table = db.get_table(num);
     let all_num = num_table.all();
     let items = num_table.scan(all_num.as_ref());
@@ -171,7 +171,7 @@ fn line_graph_1_test(strat: PlanStrategy) {
     rule.build();
     let rule_set = rsb.build();
 
-    assert!(db.run_rule_set(&rule_set));
+    assert!(db.run_rule_set(&rule_set).changed);
 
     let mut expected = Vec::from_iter(
         nodes
@@ -252,7 +252,7 @@ fn line_graph_2_test(strat: PlanStrategy) {
     rule.build();
     let rule_set = rsb.build();
 
-    assert!(db.run_rule_set(&rule_set));
+    assert!(db.run_rule_set(&rule_set).changed);
 
     let mut expected = Vec::from_iter(
         nodes.windows(2).map(|x| vec![x[0], x[1]]).chain(
@@ -674,7 +674,7 @@ fn ac_test(strat: PlanStrategy) {
                 .unwrap();
             rules.build();
             let rs = rsb.build();
-            changed |= db.run_rule_set(&rs);
+            changed |= db.run_rule_set(&rs).changed;
             let mut rsb = db.new_rule_set();
             num_rebuild(&mut rsb, cur_ts, next_ts);
             let mut add_rebuild_l = rsb.new_rule();
@@ -715,7 +715,7 @@ fn ac_test(strat: PlanStrategy) {
             rules.build();
 
             let rs = rsb.build();
-            changed |= db.run_rule_set(&rs);
+            changed |= db.run_rule_set(&rs).changed;
             let mut rsb = db.new_rule_set();
             num_rebuild(&mut rsb, cur_ts, next_ts);
             let mut add_rebuild_r = rsb.new_rule();
@@ -755,7 +755,7 @@ fn ac_test(strat: PlanStrategy) {
                 .unwrap();
             rules.build();
             let rs = rsb.build();
-            changed |= db.run_rule_set(&rs);
+            changed |= db.run_rule_set(&rs).changed;
         } else {
             // nonincremental. Just run one rule and recanonicalize everything.
             // add(x, y, id, t1) =>
@@ -804,14 +804,14 @@ fn ac_test(strat: PlanStrategy) {
                 .unwrap();
             rules.build();
             let rs = rsb.build();
-            changed |= db.run_rule_set(&rs);
+            changed |= db.run_rule_set(&rs).changed;
         }
         (next_ts, changed)
     };
     let mut cur_ts = Value::new(0);
     let mut next_ts = Value::new(1);
     loop {
-        if !run_ac_rule(&mut db, cur_ts..next_ts) {
+        if !run_ac_rule(&mut db, cur_ts..next_ts).changed {
             break;
         }
         let start = next_ts;
@@ -977,7 +977,7 @@ fn lookup_with_fallback_partial_success() {
     rb.insert(h, &[res.into(), y.into()]).unwrap();
     rb.build();
     let rs = rsb.build();
-    assert!(db.run_rule_set(&rs));
+    assert!(db.run_rule_set(&rs).changed);
 
     let h = db.get_table(h);
     let all = h.all();
@@ -1069,7 +1069,7 @@ fn call_external_with_fallback() {
     rb.insert(h, &[res.into(), y.into()]).unwrap();
     rb.build();
     let rs = rsb.build();
-    assert!(db.run_rule_set(&rs));
+    assert!(db.run_rule_set(&rs).changed);
 
     let h = db.get_table(h);
     let all = h.all();

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -101,10 +101,17 @@ fn basic_query() {
     rules
         .insert(num, &[add_a_b.into(), z.into(), Value::new(1).into()])
         .unwrap();
-    rules.build();
+    rules.build_with_description("add");
     let rule_set = rsb.build();
 
-    assert!(db.run_rule_set(&rule_set).changed);
+    let report = db.run_rule_set(&rule_set);
+
+    assert!(report.changed, "{report:?}");
+    assert_eq!(
+        report.rule_reports.get("add").unwrap().num_matches,
+        5,
+        "{report:?}"
+    );
     let num_table = db.get_table(num);
     let all_num = num_table.all();
     let items = num_table.scan(all_num.as_ref());

--- a/egglog-bridge/examples/ac.rs
+++ b/egglog-bridge/examples/ac.rs
@@ -54,7 +54,7 @@ fn main() {
         };
 
         // Running these rules on an empty database should change nothing.
-        assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap());
+        assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed);
 
         // Fill the database.
         let mut ids = Vec::new();
@@ -95,7 +95,7 @@ fn main() {
         // Saturate
         for i in 0.. {
             let iter_start = web_time::Instant::now();
-            let keep_going = egraph.run_rules(&[add_comm, add_assoc]).unwrap();
+            let keep_going = egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed;
             println!("Finished iteration {i} after {:?}", iter_start.elapsed());
             if !keep_going {
                 break;

--- a/egglog-bridge/examples/ac_tracing.rs
+++ b/egglog-bridge/examples/ac_tracing.rs
@@ -40,7 +40,7 @@ fn main() {
     };
 
     // Running these rules on an empty database should change nothing.
-    assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap());
+    assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed);
 
     // Fill the database.
     let mut ids = Vec::new();
@@ -78,7 +78,7 @@ fn main() {
         (left_root, right_root)
     };
     // Saturate
-    while egraph.run_rules(&[add_comm, add_assoc]).unwrap() {}
+    while egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed {}
     let canon_left = egraph.get_canon(left_root);
     let canon_right = egraph.get_canon(right_root);
     assert_eq!(canon_left, canon_right);

--- a/egglog-bridge/examples/math.rs
+++ b/egglog-bridge/examples/math.rs
@@ -245,7 +245,7 @@ fn main() {
 
         for i in 0..N {
             let start = Instant::now();
-            let changed = egraph.run_rules(&rules).unwrap();
+            let changed = egraph.run_rules(&rules).unwrap().changed;
             println!(
                 "Iteration {i} finished, duration={:?} (saturated={})",
                 start.elapsed(),

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -670,11 +670,7 @@ impl EGraph {
 
         let mut iteration_report = IterationReport {
             changed: rule_set_report.changed,
-            search_and_apply_time_per_rule: rule_set_report
-                .rule_reports
-                .into_iter()
-                .map(|(rule, report)| (rule, report.search_and_apply_time))
-                .collect(),
+            rule_reports: rule_set_report.rule_reports.into_iter().collect(),
             search_and_apply_time: rule_set_report.search_and_apply_time,
             merge_time: rule_set_report.merge_time,
             rebuild_time: Duration::ZERO,
@@ -1581,11 +1577,13 @@ impl<T, A: smallvec::Array<Item = T>> HasResizeWith<T> for SmallVec<A> {
 /// Running rules produces a report of the results.
 /// This includes rough timing information and whether
 /// the database was changed.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct IterationReport {
     pub changed: bool,
-    pub search_and_apply_time_per_rule: HashMap<String, Duration>,
+    pub rule_reports: HashMap<String, RuleReport>,
     pub search_and_apply_time: Duration,
     pub merge_time: Duration,
     pub rebuild_time: Duration,
 }
+
+pub use core_relations::RuleReport;

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -668,15 +668,14 @@ impl EGraph {
             return Err(PanicError(message).into());
         }
 
-        let search_and_apply_time_per_rule: HashMap<_, _> = rule_set_report
-            .rule_reports
-            .into_iter()
-            .map(|(rule, report)| (rule, report.search_and_apply_time))
-            .collect();
         let mut iteration_report = IterationReport {
             changed: rule_set_report.changed,
-            search_and_apply_time: search_and_apply_time_per_rule.values().sum(),
-            search_and_apply_time_per_rule,
+            search_and_apply_time_per_rule: rule_set_report
+                .rule_reports
+                .into_iter()
+                .map(|(rule, report)| (rule, report.search_and_apply_time))
+                .collect(),
+            search_and_apply_time: rule_set_report.search_and_apply_time,
             merge_time: rule_set_report.merge_time,
             rebuild_time: Duration::ZERO,
         };
@@ -1585,8 +1584,8 @@ impl<T, A: smallvec::Array<Item = T>> HasResizeWith<T> for SmallVec<A> {
 #[derive(Clone, Debug, Default)]
 pub struct IterationReport {
     pub changed: bool,
-    pub search_and_apply_time: Duration,
     pub search_and_apply_time_per_rule: HashMap<String, Duration>,
+    pub search_and_apply_time: Duration,
     pub merge_time: Duration,
     pub rebuild_time: Duration,
 }

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -499,9 +499,7 @@ impl EGraph {
     /// Read the contents of the given function.
     ///
     /// The callback `f` is called with each row and its subsumption status.
-    ///
-    /// Useful for debugging.
-    pub fn dump_table(&self, table: FunctionId, mut f: impl FnMut(FunctionRow<'_>)) {
+    pub fn for_each(&self, table: FunctionId, mut f: impl FnMut(FunctionRow<'_>)) {
         self.for_each_while(table, |row| {
             f(row);
             true

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -59,7 +59,7 @@ fn ac_test(tracing: bool, can_subsume: bool) {
     };
 
     // Running these rules on an empty database should change nothing.
-    assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap());
+    assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed);
 
     // Fill the database.
     let mut ids = Vec::new();
@@ -88,7 +88,7 @@ fn ac_test(tracing: bool, can_subsume: bool) {
         (left_root, right_root)
     };
     // Saturate
-    while egraph.run_rules(&[add_comm, add_assoc]).unwrap() {}
+    while egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed {}
     let canon_left = egraph.get_canon(left_root);
     let canon_right = egraph.get_canon(right_root);
     assert_eq!(canon_left, canon_right, "failed to reassociate!");
@@ -161,7 +161,7 @@ fn ac_fail() {
     };
 
     // Running these rules on an empty database should change nothing.
-    assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap());
+    assert!(!egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed);
 
     // Fill the database.
     let mut ids = Vec::new();
@@ -199,7 +199,7 @@ fn ac_fail() {
         (left_root, right_root)
     };
     // Saturate
-    while egraph.run_rules(&[add_comm, add_assoc]).unwrap() {}
+    while egraph.run_rules(&[add_comm, add_assoc]).unwrap().changed {}
     let canon_left = egraph.get_canon(left_root);
     let canon_right = egraph.get_canon(right_root);
     assert_ne!(canon_left, canon_right);
@@ -443,7 +443,7 @@ fn math_test(mut egraph: EGraph, can_subsume: bool) {
     }
 
     for _ in 0..N {
-        if !egraph.run_rules(&rules).unwrap() {
+        if !egraph.run_rules(&rules).unwrap().changed {
             break;
         }
     }
@@ -708,20 +708,20 @@ fn container_test() {
         vec![vec![], vec![egraph.get_canon(ids[1])]],
     );
 
-    assert!(egraph.run_rules(&[vec_expand]).unwrap());
+    assert!(egraph.run_rules(&[vec_expand]).unwrap().changed);
     assert_eq!(dump_vecs(&egraph).len(), 4);
     // We have 2 new vectors with a last element. Each of those should spawn two more, adding 4.
-    assert!(egraph.run_rules(&[vec_expand]).unwrap());
+    assert!(egraph.run_rules(&[vec_expand]).unwrap().changed);
     assert_eq!(dump_vecs(&egraph).len(), 8);
     // We have 4 new vectors with a last element. Each of those should spawn two more, adding 8.
-    assert!(egraph.run_rules(&[vec_expand]).unwrap());
+    assert!(egraph.run_rules(&[vec_expand]).unwrap().changed);
     assert_eq!(dump_vecs(&egraph).len(), 16);
 
     // Now we want to saturate `eval_add`. This should collapse a bunch of new vectors.
 
     let mut saturated = false;
     for _ in 0..20 {
-        saturated = !egraph.run_rules(&[eval_add]).unwrap();
+        saturated = !egraph.run_rules(&[eval_add]).unwrap().changed;
         if saturated {
             break;
         }
@@ -774,7 +774,7 @@ fn rhs_only_rule() {
     let mut contents = Vec::new();
 
     assert!(contents.is_empty());
-    assert!(egraph.run_rules(&[add_data]).unwrap());
+    assert!(egraph.run_rules(&[add_data]).unwrap().changed);
     egraph.for_each(num_table, |func_row| {
         assert!(!func_row.subsumed);
         contents.push(func_row.vals.to_vec());
@@ -802,9 +802,9 @@ fn rhs_only_rule_only_runs_once() {
         rb.build()
     };
 
-    assert!(!egraph.run_rules(&[inc_counter_rule]).unwrap());
+    assert!(!egraph.run_rules(&[inc_counter_rule]).unwrap().changed);
     assert_eq!(counter.load(Ordering::SeqCst), 1);
-    assert!(!egraph.run_rules(&[inc_counter_rule]).unwrap());
+    assert!(!egraph.run_rules(&[inc_counter_rule]).unwrap().changed);
     assert_eq!(counter.load(Ordering::SeqCst), 1);
 }
 
@@ -873,7 +873,7 @@ fn mergefn_arithmetic() {
     };
 
     // Run the first rule and check state
-    assert!(egraph.run_rules(&[rule1]).unwrap());
+    assert!(egraph.run_rules(&[rule1]).unwrap().changed);
     let mut contents = Vec::new();
     egraph.for_each(f_table, |func_row| {
         assert!(!func_row.subsumed);
@@ -896,7 +896,7 @@ fn mergefn_arithmetic() {
     // Run the second rule and check state
     // Expected: (f 1 1) because 1 + (0 * 5) = 1
     // Expected: (f 2 7) because 1 + (1 * 6) = 7
-    assert!(egraph.run_rules(&[rule2]).unwrap());
+    assert!(egraph.run_rules(&[rule2]).unwrap().changed);
     contents.clear();
     egraph.for_each(f_table, |func_row| {
         assert!(!func_row.subsumed);
@@ -919,7 +919,7 @@ fn mergefn_arithmetic() {
     // Run the third rule and check state
     // Expected: (f 1 4) because 1 + (1 * 3) = 4
     // Expected: (f 2 29) because 1 + (7 * 4) = 29
-    assert!(egraph.run_rules(&[rule3]).unwrap());
+    assert!(egraph.run_rules(&[rule3]).unwrap().changed);
     contents.clear();
     egraph.for_each(f_table, |func_row| {
         assert!(!func_row.subsumed);
@@ -1001,7 +1001,7 @@ fn mergefn_nested_function() {
     };
 
     // First run of the rule
-    assert!(egraph.run_rules(&[write_rule]).unwrap());
+    assert!(egraph.run_rules(&[write_rule]).unwrap().changed);
     let f_entries_1 = get_f_entries(&egraph);
     let g_entries_1 = get_g_entries(&egraph);
     assert_eq!(f_entries_1.len(), 2);
@@ -1026,7 +1026,7 @@ fn mergefn_nested_function() {
     };
 
     // Second run of the rule - should trigger merging with previous values
-    assert!(egraph.run_rules(&[set_rule]).unwrap());
+    assert!(egraph.run_rules(&[set_rule]).unwrap().changed);
     let f_entries_2 = get_f_entries(&egraph);
     let g_entries_2 = get_g_entries(&egraph);
     assert_eq!(f_entries_2.len(), 2);

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -991,7 +991,10 @@ fn mergefn_nested_function() {
         let mut entries = Vec::new();
         egraph.dump_table(f_table, |func_row| {
             assert!(!func_row.subsumed);
-            entries.push((*egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]), func_row.vals[1]));
+            entries.push((
+                *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
+                func_row.vals[1],
+            ));
         });
         entries.sort();
         entries
@@ -1114,7 +1117,10 @@ fn constrain_prims_simple() {
         let mut entries = Vec::new();
         egraph.dump_table(table, |func_row| {
             assert!(!func_row.subsumed);
-            entries.push((*egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]), func_row.vals[1]));
+            entries.push((
+                *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
+                func_row.vals[1],
+            ));
         });
         entries.sort();
         entries
@@ -1208,7 +1214,10 @@ fn constrain_prims_abstract() {
         let mut entries = Vec::new();
         egraph.dump_table(table, |func_row| {
             assert!(!func_row.subsumed);
-            entries.push((*egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]), func_row.vals[1]));
+            entries.push((
+                *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
+                func_row.vals[1],
+            ));
         });
         entries.sort();
         entries
@@ -1276,7 +1285,10 @@ fn basic_subsumption() {
         let mut entries = Vec::new();
         let mut num_subsumed = 0;
         egraph.dump_table(table, |func_row| {
-            entries.push((*egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]), func_row.vals[1]));
+            entries.push((
+                *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
+                func_row.vals[1],
+            ));
             if func_row.subsumed {
                 num_subsumed += 1;
             }
@@ -1294,7 +1306,10 @@ fn basic_subsumption() {
     egraph.run_rules(&[subsume_f]).unwrap();
     let f = get_entries(&egraph, f_table);
     assert_eq!((f.0.len(), f.1), (3, 2));
-    assert_eq!(f.0.iter().map(|(x, _)| *x).collect::<Vec<_>>(), vec![1, 2, 3]);
+    assert_eq!(
+        f.0.iter().map(|(x, _)| *x).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
     egraph.run_rules(&[copy_to_g]).unwrap();
     let g = get_entries(&egraph, g_table);
     assert_eq!((g.0.len(), g.1), (1, 0));

--- a/egglog-bridge/src/tests.rs
+++ b/egglog-bridge/src/tests.rs
@@ -94,7 +94,7 @@ fn ac_test(tracing: bool, can_subsume: bool) {
     assert_eq!(canon_left, canon_right, "failed to reassociate!");
     if tracing {
         let mut row = Vec::new();
-        egraph.dump_table(add_table, |func_row| {
+        egraph.for_each(add_table, |func_row| {
             assert!(!func_row.subsumed);
             row.clear();
             row.extend_from_slice(func_row.vals);
@@ -486,7 +486,7 @@ fn math_test(mut egraph: EGraph, can_subsume: bool) {
 
     if egraph.tracing {
         let mut row = Vec::new();
-        egraph.dump_table(mul, |func_row| {
+        egraph.for_each(mul, |func_row| {
             assert!(!func_row.subsumed);
             row.clear();
             row.extend_from_slice(func_row.vals);
@@ -775,7 +775,7 @@ fn rhs_only_rule() {
 
     assert!(contents.is_empty());
     assert!(egraph.run_rules(&[add_data]).unwrap());
-    egraph.dump_table(num_table, |func_row| {
+    egraph.for_each(num_table, |func_row| {
         assert!(!func_row.subsumed);
         contents.push(func_row.vals.to_vec());
     });
@@ -875,7 +875,7 @@ fn mergefn_arithmetic() {
     // Run the first rule and check state
     assert!(egraph.run_rules(&[rule1]).unwrap());
     let mut contents = Vec::new();
-    egraph.dump_table(f_table, |func_row| {
+    egraph.for_each(f_table, |func_row| {
         assert!(!func_row.subsumed);
         contents.push((
             *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
@@ -898,7 +898,7 @@ fn mergefn_arithmetic() {
     // Expected: (f 2 7) because 1 + (1 * 6) = 7
     assert!(egraph.run_rules(&[rule2]).unwrap());
     contents.clear();
-    egraph.dump_table(f_table, |func_row| {
+    egraph.for_each(f_table, |func_row| {
         assert!(!func_row.subsumed);
         contents.push((
             *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
@@ -921,7 +921,7 @@ fn mergefn_arithmetic() {
     // Expected: (f 2 29) because 1 + (7 * 4) = 29
     assert!(egraph.run_rules(&[rule3]).unwrap());
     contents.clear();
-    egraph.dump_table(f_table, |func_row| {
+    egraph.for_each(f_table, |func_row| {
         assert!(!func_row.subsumed);
         contents.push((
             *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
@@ -978,7 +978,7 @@ fn mergefn_nested_function() {
     // Helper function to get all g-table entries
     let get_g_entries = |egraph: &EGraph| {
         let mut entries = Vec::new();
-        egraph.dump_table(g_table, |func_row| {
+        egraph.for_each(g_table, |func_row| {
             assert!(!func_row.subsumed);
             entries.push((func_row.vals[0], func_row.vals[1], func_row.vals[2]));
         });
@@ -989,7 +989,7 @@ fn mergefn_nested_function() {
     // Helper function to get all f-table entries
     let get_f_entries = |egraph: &EGraph| {
         let mut entries = Vec::new();
-        egraph.dump_table(f_table, |func_row| {
+        egraph.for_each(f_table, |func_row| {
             assert!(!func_row.subsumed);
             entries.push((
                 *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
@@ -1115,7 +1115,7 @@ fn constrain_prims_simple() {
     };
     let get_entries = |egraph: &EGraph, table: FunctionId| {
         let mut entries = Vec::new();
-        egraph.dump_table(table, |func_row| {
+        egraph.for_each(table, |func_row| {
             assert!(!func_row.subsumed);
             entries.push((
                 *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
@@ -1212,7 +1212,7 @@ fn constrain_prims_abstract() {
     };
     let get_entries = |egraph: &EGraph, table: FunctionId| {
         let mut entries = Vec::new();
-        egraph.dump_table(table, |func_row| {
+        egraph.for_each(table, |func_row| {
             assert!(!func_row.subsumed);
             entries.push((
                 *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
@@ -1284,7 +1284,7 @@ fn basic_subsumption() {
     let get_entries = |egraph: &EGraph, table: FunctionId| {
         let mut entries = Vec::new();
         let mut num_subsumed = 0;
-        egraph.dump_table(table, |func_row| {
+        egraph.for_each(table, |func_row| {
             entries.push((
                 *egraph.primitives().unwrap_ref::<i64>(func_row.vals[0]),
                 func_row.vals[1],


### PR DESCRIPTION
This PR fixes some nits and adds a very simple `RunReport`. We can maybe extend it in the future, but it wasn't clear to me that it was possible to separate the timing of different rules well, especially in the non-parallel case.

Even if we could separate the rule timings from each other, the new backend runs the query and action executions in an interleaved way, so we definitely can't support all of the different timings from the old backend's `RunReport`.