### PR TITLE
Create TableAction and UnionAction, implement insert and remove

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -264,7 +264,10 @@ impl<'a> ExecutionState<'a> {
             changed: false,
         }
     }
+
     /// Stage an insertion of the given row into `table`.
+    ///
+    /// If you are using `egglog`, consider using `egglog_bridge::TableAction`.
     pub fn stage_insert(&mut self, table: TableId, row: &[Value]) {
         self.buffers
             .get_or_insert(table, || self.db.table_info[table].table.new_buffer())
@@ -273,6 +276,8 @@ impl<'a> ExecutionState<'a> {
     }
 
     /// Stage a removal of the given row from `table` if it is present.
+    ///
+    /// If you are using `egglog`, consider using `egglog_bridge::TableAction`.
     pub fn stage_remove(&mut self, table: TableId, key: &[Value]) {
         self.buffers
             .get_or_insert(table, || self.db.table_info[table].table.new_buffer())
@@ -318,6 +323,8 @@ impl<'a> ExecutionState<'a> {
     /// merge functions sometimes need to get the result of an insertion. For
     /// such cases, executions keep a cache of "predicted" values for a given
     /// mapping that manage the insertions, etc.
+    ///
+    /// If you are using `egglog`, consider using `egglog_bridge::TableAction`.
     pub fn predict_val(
         &mut self,
         table: TableId,

--- a/egglog-bridge/src/lib.rs
+++ b/egglog-bridge/src/lib.rs
@@ -1353,6 +1353,7 @@ impl TableAction {
 }
 
 /// A variant of `TableAction` for the union-find.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct UnionAction {
     table: TableId,
     timestamp: CounterId,


### PR DESCRIPTION
I think that I want something like this for the rules-in-Rust-without-strings API. At the very least, we need to expose ways to do the basic actions (lookup, union, insert, delete, subsume) from inside `ExternalFunction`s. I am also open to splitting each operation into its own struct.

I am not quite sure how to implement `subsume`.