### PR TITLE
Better caching

### DIFF
--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -225,6 +225,18 @@ pub struct IdVec<K, V> {
     _marker: std::marker::PhantomData<K>,
 }
 
+impl<K, V> IdVec<K, V> {
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+}
+
 impl<K, V> Default for IdVec<K, V> {
     fn default() -> IdVec<K, V> {
         IdVec {


### PR DESCRIPTION
This PR adds a more conventional trie node back to the free join implementation in this crate. 

The initial implementation of free join in the backend did not store the hash index in a node that multiple iterations of the join could reference directly. Instead it stored them in a shared hash table keyed by `table, column, subset`. This allows for less recomputation of indexes, but at the cost of doing a hashtable lookup to actually get access to the index.

This seemed to be working fine for a while, but it seems like it is tripping some bad behavior in the `math-microbenchmark` workload in `egglog` with the new backend wired in, where quite a lot of time is spent in the hashtable lookup. (This makes sense in retrospect, as `Subset`s can get large and lookups are going to be O(n) in the size of the subset).

This PR moves us back to a more conventional representation where different recursive scans of an atom can share the same index by virtue of being passed the same information (trie node). This gets most of the sharing back, but without needing a hashtable lookup.