### PR TITLE
More optimizations

### DIFF
--- a/concurrency/benches/simple_read.rs
+++ b/concurrency/benches/simple_read.rs
@@ -56,7 +56,7 @@ impl<T: Send + Sync> ReadLock<T> for ReadOptimizedLock<T> {
     fn new(data: T) -> Self {
         ReadOptimizedLock::new(data)
     }
-    fn read(&self) -> MutexReader<T> {
+    fn read(&self) -> MutexReader<'_, T> {
         self.read()
     }
 }

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -114,7 +114,7 @@ impl<T> ReadOptimizedLock<T> {
     /// Create a `Reader` object that grants read access to the data.
     ///
     /// This method will block for any ongoing writes to complete.
-    pub fn read(&self) -> MutexReader<T> {
+    pub fn read(&self) -> MutexReader<'_, T> {
         loop {
             let guard = self.token.load();
             match guard.as_ref() {
@@ -139,7 +139,7 @@ impl<T> ReadOptimizedLock<T> {
         }
     }
 
-    pub fn lock(&self) -> MutexWriter<T> {
+    pub fn lock(&self) -> MutexWriter<'_, T> {
         loop {
             let guard = self.token.load();
             match guard.as_ref() {

--- a/concurrency/src/tests.rs
+++ b/concurrency/src/tests.rs
@@ -160,7 +160,7 @@ fn basic_parallel_vec_write() {
             let v = v.clone();
             thread::spawn(move || {
                 let dst = v.write_contents((0..PER_THREAD).map(|j| i * PER_THREAD + j + 100));
-                assert!(dst % 10 == 0);
+                assert!(dst.is_multiple_of(10));
                 finish.wait();
             })
         })

--- a/core-relations/src/action/mask.rs
+++ b/core-relations/src/action/mask.rs
@@ -400,7 +400,7 @@ pub(crate) enum ValueSource<'a, T> {
 /// difficult to call and requires materializing a vector for each iteration. This macro
 /// special-cases small slices of arguments and uses custom iterator invocations for those,
 /// avoiding any heap allocations for them.
-macro_rules! process_vec {
+macro_rules! for_each_binding_with_mask {
     ($mask:expr, $args:expr, $bindings:expr, |$iter:ident| $body:expr) => {{
         match $args {
             [] => {

--- a/core-relations/src/action/mask.rs
+++ b/core-relations/src/action/mask.rs
@@ -253,11 +253,13 @@ where
     Vec<T>: InPoolSet<PoolSet>,
 {
     type Item = Pooled<Vec<T>>;
+
     fn inc_counter(&mut self) -> usize {
         let res = self.counter;
         self.counter += 1;
         res
     }
+
     fn get_at(&mut self, idx: usize) -> IterResult<Self::Item> {
         if self.mask.contains(idx) {
             let mut result = self.pool.get();
@@ -273,6 +275,7 @@ where
             IterResult::Done
         }
     }
+
     fn remove(&mut self, idx: usize) {
         self.mask.set(idx, false);
     }
@@ -285,11 +288,13 @@ pub(crate) struct MaskIterUnit<'mask> {
 
 impl<'mask> MaskIter for MaskIterUnit<'mask> {
     type Item = ();
+
     fn inc_counter(&mut self) -> usize {
         let res = self.counter;
         self.counter += 1;
         res
     }
+
     fn get_at(&mut self, idx: usize) -> IterResult<()> {
         if self.mask.contains(idx) {
             IterResult::Item(())
@@ -299,6 +304,7 @@ impl<'mask> MaskIter for MaskIterUnit<'mask> {
             IterResult::Done
         }
     }
+
     fn remove(&mut self, idx: usize) {
         self.mask.set(idx, false);
     }
@@ -312,11 +318,13 @@ pub(crate) struct MaskIterBase<'slice, 'mask, T> {
 
 impl<'slice, T> MaskIter for MaskIterBase<'slice, '_, T> {
     type Item = &'slice T;
+
     fn inc_counter(&mut self) -> usize {
         let res = self.counter;
         self.counter += 1;
         res
     }
+
     fn get_at(&mut self, idx: usize) -> IterResult<&'slice T> {
         if self.mask.contains(idx) {
             IterResult::Item(&self.slice[idx])
@@ -326,6 +334,7 @@ impl<'slice, T> MaskIter for MaskIterBase<'slice, '_, T> {
             IterResult::Done
         }
     }
+
     fn remove(&mut self, idx: usize) {
         self.mask.set(idx, false);
     }
@@ -337,9 +346,11 @@ pub(crate) struct ZipIter<'slice, Base, T> {
 
 impl<'slice, Base: MaskIter, T> MaskIter for ZipIter<'slice, Base, T> {
     type Item = (Base::Item, &'slice T);
+
     fn inc_counter(&mut self) -> usize {
         self.base.inc_counter()
     }
+
     fn get_at(&mut self, idx: usize) -> IterResult<Self::Item> {
         match self.base.get_at(idx) {
             IterResult::Item(base) => IterResult::Item((base, &self.slice[idx])),

--- a/core-relations/src/action/mask.rs
+++ b/core-relations/src/action/mask.rs
@@ -63,7 +63,7 @@ impl Mask {
         self.data.union_with(&other.data);
     }
 
-    pub(crate) fn empty_iter(&mut self) -> MaskIterUnit {
+    pub(crate) fn empty_iter(&mut self) -> MaskIterUnit<'_> {
         MaskIterUnit {
             counter: 0,
             mask: &mut self.data,
@@ -231,7 +231,7 @@ pub(crate) trait MaskIter {
         })
     }
 
-    fn zip<T>(self, slice: &[T]) -> ZipIter<Self, T>
+    fn zip<T>(self, slice: &[T]) -> ZipIter<'_, Self, T>
     where
         Self: Sized,
     {

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -155,6 +155,9 @@ impl Bindings {
     fn add_mapping(&mut self, var: Variable, vals: &[Value]) {
         let start = self.data.len();
         self.data.extend_from_slice(vals);
+        // We have a flat representation of the data, meaning that writing more than
+        // `max_batch_size` values to `var` could overwrite values for a different variable, which
+        // would produce some mysterious results that are hard to debug.
         debug_assert!(vals.len() <= self.max_batch_size);
         if vals.len() < self.max_batch_size {
             let target_len = self.data.len() + self.max_batch_size - vals.len();

--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -23,10 +23,6 @@ use self::mask::{Mask, MaskIter, ValueSource};
 
 pub(crate) mod mask;
 
-/// Threshold for choosing between vectorized and non-vectorized execution.
-/// When the number of bound variables is below this threshold, non-vectorized execution is used.
-const VECTORIZATION_THRESHOLD: usize = 4;
-
 #[cfg(test)]
 mod tests;
 
@@ -453,41 +449,16 @@ impl ExecutionState<'_> {
             bindings.matches = 1;
         }
 
-        // Choose execution strategy based on number of bindings
-        if bindings.matches < VECTORIZATION_THRESHOLD {
-            let todo_remove_nonvectorized = 1;
-            // Non-vectorized execution for small batch sizes. This avoids the need for a large
-            // number of temporary vectors and masks.
-            let mut scratch = with_pool_set(|ps| ps.get::<Vec<Value>>());
-            let mut single_bindings = DenseIdMap::new();
-
-            for binding_idx in 0..bindings.matches {
-                single_bindings.clear();
-                // Extract bindings for this row
-                for (var, _) in bindings.vars.iter() {
-                    if binding_idx < bindings.matches {
-                        single_bindings.insert(var, bindings[var][binding_idx]);
-                    }
-                }
-
-                for instr in instrs {
-                    if !self.run_instr(instr, &mut single_bindings, &mut scratch) {
-                        break;
-                    }
-                }
+        // Vectorized execution for larger batch sizes
+        let mut mask = with_pool_set(|ps| Mask::new(0..bindings.matches, ps));
+        for instr in instrs {
+            if mask.is_empty() {
+                break;
             }
-        } else {
-            // Vectorized execution for larger batch sizes
-            let mut mask = with_pool_set(|ps| Mask::new(0..bindings.matches, ps));
-            for instr in instrs {
-                if mask.is_empty() {
-                    break;
-                }
-                self.run_instr_vectorized(&mut mask, instr, bindings);
-            }
+            self.run_instr(&mut mask, instr, bindings);
         }
     }
-    fn run_instr_vectorized(&mut self, mask: &mut Mask, inst: &Instr, bindings: &mut Bindings) {
+    fn run_instr(&mut self, mask: &mut Mask, inst: &Instr, bindings: &mut Bindings) {
         fn assert_impl(
             bindings: &mut Bindings,
             mask: &mut Mask,
@@ -754,228 +725,6 @@ impl ExecutionState<'_> {
                 let ctr_val = Value::from_usize(self.read_counter(*counter));
                 vals.resize(bindings.matches, ctr_val);
                 bindings.insert(*dst, &vals);
-            }
-        }
-    }
-
-    fn run_instr(
-        &mut self,
-        inst: &Instr,
-        bindings: &mut DenseIdMap<Variable, Value>,
-        scratch: &mut Vec<Value>,
-    ) -> bool {
-        fn assert_impl(
-            bindings: &DenseIdMap<Variable, Value>,
-            l: &QueryEntry,
-            r: &QueryEntry,
-            op: impl Fn(Value, Value) -> bool,
-        ) -> bool {
-            let l_val = match l {
-                QueryEntry::Var(v) => bindings[*v],
-                QueryEntry::Const(c) => *c,
-            };
-            let r_val = match r {
-                QueryEntry::Var(v) => bindings[*v],
-                QueryEntry::Const(c) => *c,
-            };
-            op(l_val, r_val)
-        }
-
-        fn eval_query_entry(entry: &QueryEntry, bindings: &DenseIdMap<Variable, Value>) -> Value {
-            match entry {
-                QueryEntry::Var(v) => bindings[*v],
-                QueryEntry::Const(c) => *c,
-            }
-        }
-
-        fn eval_write_val(
-            val: &WriteVal,
-            bindings: &DenseIdMap<Variable, Value>,
-            row: &[Value],
-            exec_state: &ExecutionState,
-        ) -> Value {
-            match val {
-                WriteVal::QueryEntry(entry) => eval_query_entry(entry, bindings),
-                WriteVal::IncCounter(ctr) => Value::from_usize(exec_state.inc_counter(*ctr)),
-                WriteVal::CurrentVal(ix) => row[*ix],
-            }
-        }
-
-        match inst {
-            Instr::LookupOrInsertDefault {
-                table: table_id,
-                args,
-                default,
-                dst_col,
-                dst_var,
-            } => {
-                scratch.clear();
-                scratch.extend(args.iter().map(|arg| eval_query_entry(arg, bindings)));
-                let table = &self.db.table_info[*table_id].table;
-
-                if let Some(val) = table.get_row_column(scratch, *dst_col) {
-                    bindings.insert(*dst_var, val);
-                    return true;
-                }
-
-                let prediction_key = (*table_id, SmallVec::<[Value; 3]>::from_slice(scratch));
-                if let Some(predicted_row) = self.predicted.data.get(&prediction_key) {
-                    bindings.insert(*dst_var, predicted_row[dst_col.index()]);
-                    return true;
-                }
-
-                scratch.reserve(default.len());
-                for val in default {
-                    let val = eval_write_val(val, bindings, scratch, self);
-                    scratch.push(val);
-                }
-
-                let predicted_row = with_pool_set(|ps| {
-                    let mut pooled = ps.get::<Vec<Value>>();
-                    pooled.extend_from_slice(scratch);
-                    pooled
-                });
-
-                bindings.insert(*dst_var, predicted_row[dst_col.index()]);
-                self.predicted.data.insert(prediction_key, predicted_row);
-
-                self.buffers
-                    .get_or_insert(*table_id, || {
-                        self.db.table_info[*table_id].table.new_buffer()
-                    })
-                    .stage_insert(scratch);
-                self.changed = true;
-                true
-            }
-            Instr::LookupWithDefault {
-                table,
-                args,
-                dst_col,
-                dst_var,
-                default,
-            } => {
-                scratch.clear();
-                scratch.extend(args.iter().map(|arg| eval_query_entry(arg, bindings)));
-                let table = &self.db.table_info[*table].table;
-
-                if let Some(val) = table.get_row_column(scratch, *dst_col) {
-                    bindings.insert(*dst_var, val);
-                    true
-                } else {
-                    bindings.insert(*dst_var, eval_query_entry(default, bindings));
-                    true
-                }
-            }
-            Instr::Lookup {
-                table,
-                args,
-                dst_col,
-                dst_var,
-            } => {
-                scratch.clear();
-                scratch.extend(args.iter().map(|arg| eval_query_entry(arg, bindings)));
-                let table = &self.db.table_info[*table].table;
-
-                if let Some(row) = table.get_row(scratch) {
-                    bindings.insert(*dst_var, row.vals[dst_col.index()]);
-                    true
-                } else {
-                    false
-                }
-            }
-            Instr::LookupWithFallback {
-                table: table_id,
-                table_key,
-                func,
-                func_args,
-                dst_col,
-                dst_var,
-            } => {
-                scratch.clear();
-                scratch.extend(table_key.iter().map(|arg| eval_query_entry(arg, bindings)));
-                let table = &self.db.table_info[*table_id].table;
-
-                if let Some(val) = table.get_row_column(scratch, *dst_col) {
-                    bindings.insert(*dst_var, val);
-                    return true;
-                }
-
-                scratch.clear();
-                scratch.extend(func_args.iter().map(|arg| eval_query_entry(arg, bindings)));
-                if let Some(val) = self.db.external_funcs[*func].invoke(self, scratch) {
-                    bindings.insert(*dst_var, val);
-                    true
-                } else {
-                    false
-                }
-            }
-            Instr::Insert { table, vals } => {
-                scratch.clear();
-                scratch.extend(vals.iter().map(|val| eval_query_entry(val, bindings)));
-                self.stage_insert(*table, scratch);
-                true
-            }
-            Instr::InsertIfEq { table, l, r, vals } => {
-                if assert_impl(bindings, l, r, |l, r| l == r) {
-                    scratch.clear();
-                    scratch.extend(vals.iter().map(|val| eval_query_entry(val, bindings)));
-                    self.stage_insert(*table, scratch);
-                }
-                true
-            }
-            Instr::Remove { table, args } => {
-                scratch.clear();
-                scratch.extend(args.iter().map(|arg| eval_query_entry(arg, bindings)));
-                self.stage_remove(*table, scratch);
-                true
-            }
-            Instr::External { func, args, dst } => {
-                scratch.clear();
-                scratch.extend(args.iter().map(|arg| eval_query_entry(arg, bindings)));
-                if let Some(val) = self.db.external_funcs[*func].invoke(self, scratch) {
-                    bindings.insert(*dst, val);
-                    true
-                } else {
-                    false
-                }
-            }
-            Instr::ExternalWithFallback {
-                f1,
-                args1,
-                f2,
-                args2,
-                dst,
-            } => {
-                scratch.clear();
-                scratch.extend(args1.iter().map(|arg| eval_query_entry(arg, bindings)));
-                if let Some(val) = self.db.external_funcs[*f1].invoke(self, scratch) {
-                    bindings.insert(*dst, val);
-                    return true;
-                }
-
-                scratch.clear();
-                scratch.extend(args2.iter().map(|arg| eval_query_entry(arg, bindings)));
-                if let Some(val) = self.db.external_funcs[*f2].invoke(self, scratch) {
-                    bindings.insert(*dst, val);
-                    true
-                } else {
-                    false
-                }
-            }
-            Instr::AssertAnyNe { ops, divider } => {
-                scratch.clear();
-                scratch.extend(ops.iter().map(|op| eval_query_entry(op, bindings)));
-                scratch[0..*divider]
-                    .iter()
-                    .zip(&scratch[*divider..])
-                    .any(|(l, r)| l != r)
-            }
-            Instr::AssertEq(l, r) => assert_impl(bindings, l, r, |l, r| l == r),
-            Instr::AssertNe(l, r) => assert_impl(bindings, l, r, |l, r| l != r),
-            Instr::ReadCounter { counter, dst } => {
-                let val = Value::from_usize(self.read_counter(*counter));
-                bindings.insert(*dst, val);
-                true
             }
         }
     }

--- a/core-relations/src/action/tests.rs
+++ b/core-relations/src/action/tests.rs
@@ -72,7 +72,7 @@ fn fill_vec() {
 
     // The vector itself should have i32::MAX in for the odd indexes.
     for (i, x) in out.iter().copied().enumerate() {
-        if i % 2 == 0 {
+        if i.is_multiple_of(2) {
             assert_eq!(x, i as i32);
         } else {
             assert_eq!(x, i32::MAX);

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -579,10 +579,10 @@ impl<'a> JoinState<'a> {
                                 return;
                             }
                             updates.refine_atom(a.atom, sub);
+                            updates.new_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
                             }
-                            updates.new_frame();
                         })
                     });
                     drain_updates!(updates);
@@ -604,10 +604,10 @@ impl<'a> JoinState<'a> {
                                 return;
                             }
                             updates.refine_atom(a.atom, sub);
+                            updates.new_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
                             }
-                            updates.new_frame();
                         })
                     });
                     drain_updates!(updates);

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -473,8 +473,9 @@ impl<'a> JoinState<'a> {
         }
         let chunk_size = action_buf.morsel_size(cur, instr_order.len());
         let mut cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);
-        if cur_size > 32 && cur_size % 3 == 1 && cur < instr_order.len() - 1 {
-            // If we have a reasonable number of tuples to process, adjust the variable order.
+        if cur_size > 32 && cur % 3 == 1 && cur < instr_order.len() - 1 {
+            // If we have a reasonable number of tuples to process, adjust the variable order every
+            // 3 rounds, but always make sure to readjust on the second roung.
             sort_plan_by_size(instr_order, cur, &plan.stages.instrs, binding_info);
             cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);
         }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -472,10 +472,11 @@ impl<'a> JoinState<'a> {
             return;
         }
         let chunk_size = action_buf.morsel_size(cur, instr_order.len());
-        let cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);
-        if cur_size > 32 && cur < instr_order.len() - 1 {
+        let mut cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);
+        if cur_size > 32 && cur_size % 2 == 1 && cur < instr_order.len() - 1 {
             // If we have a reasonable number of tuples to process, adjust the variable order.
             sort_plan_by_size(instr_order, cur, &plan.stages.instrs, binding_info);
+            cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);
         }
 
         // Helper macro (not its own method to appease the borrow checker).

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -1,7 +1,7 @@
 //! Core free join execution.
 
 use std::{
-    iter, mem,
+    cmp, iter, mem,
     sync::{atomic::AtomicUsize, Arc, OnceLock},
 };
 
@@ -12,15 +12,18 @@ use web_time::Instant;
 use crate::{
     action::{Bindings, ExecutionState, PredictedVals},
     common::{DashMap, Value},
-    free_join::{get_index_from_tableinfo, RuleReport, RuleSetReport},
+    free_join::{
+        frame_update::{FrameUpdates, UpdateInstr},
+        get_index_from_tableinfo, RuleReport, RuleSetReport,
+    },
     hash_index::{ColumnIndex, IndexBase, TupleIndex},
     offsets::{Offsets, SortedOffsetVector, Subset},
     parallel_heuristics::parallelize_db_level_op,
-    pool::{Clear, Pooled},
+    pool::Pooled,
     query::RuleSet,
     row_buffer::TaggedRowBuffer,
     table_spec::{ColumnId, Offset, WrappedTableRef},
-    Constraint, OffsetRange, Pool, PoolSet, SubsetRef,
+    Constraint, OffsetRange, Pool, SubsetRef,
 };
 
 use super::{
@@ -477,6 +480,7 @@ impl<'a> JoinState<'a> {
             // If we have a reasonable number of tuples to process, adjust the variable order.
             sort_plan_by_size(instr_order, cur, &plan.stages.instrs, binding_info);
         }
+
         // Helper macro (not its own method to appease the borrow checker).
         macro_rules! drain_updates {
             ($updates:expr) => {
@@ -484,15 +488,17 @@ impl<'a> JoinState<'a> {
                     drain_updates_parallel!($updates)
                 } else {
                     drain_reg(|| {
-                        for mut update in $updates.drain(..) {
-                            for (var, val) in update.bindings.drain(..) {
+                        $updates.drain(|update| match update {
+                            UpdateInstr::PushBinding(var, val) => {
                                 binding_info.bindings.insert(var, val);
                             }
-                            for (atom, subset) in update.refinements.drain(..) {
+                            UpdateInstr::RefineAtom(atom, subset) => {
                                 binding_info.insert_subset(atom, subset);
                             }
-                            self.run_plan(plan, instr_order, cur + 1, binding_info, action_buf);
-                        }
+                            UpdateInstr::EndFrame => {
+                                self.run_plan(plan, instr_order, cur + 1, binding_info, action_buf);
+                            }
+                        })
                     })
                 }
             };
@@ -500,37 +506,47 @@ impl<'a> JoinState<'a> {
         macro_rules! drain_updates_parallel {
             ($updates:expr) => {{
                 drain_parallel(|| {
-                    let mut updates = mem::take(&mut $updates);
                     let predicted = self.preds;
                     let db = self.db;
                     action_buf.recur(
-                        binding_info,
-                        instr_order,
+                        BorrowedLocalState {
+                            binding_info,
+                            instr_order,
+                            updates: &mut $updates,
+                        },
                         move || {
                             ExecutionState::new(predicted, db.read_only_view(), Default::default())
                         },
-                        move |binding_info, instr_order, buf| {
-                            for mut update in updates.drain(..) {
-                                for (var, val) in update.bindings.drain(..) {
+                        move |BorrowedLocalState {
+                                  binding_info,
+                                  instr_order,
+                                  updates,
+                              },
+                              buf| {
+                            updates.drain(|update| match update {
+                                UpdateInstr::PushBinding(var, val) => {
                                     binding_info.bindings.insert(var, val);
                                 }
-                                for (atom, subset) in update.refinements.drain(..) {
+                                UpdateInstr::RefineAtom(atom, subset) => {
                                     binding_info.insert_subset(atom, subset);
                                 }
-                                JoinState {
-                                    db,
-                                    preds: predicted,
+                                UpdateInstr::EndFrame => {
+                                    JoinState {
+                                        db,
+                                        preds: predicted,
+                                    }
+                                    .run_plan(
+                                        plan,
+                                        instr_order,
+                                        cur + 1,
+                                        binding_info,
+                                        buf,
+                                    );
                                 }
-                                .run_plan(
-                                    plan,
-                                    instr_order,
-                                    cur + 1,
-                                    binding_info,
-                                    buf,
-                                );
-                            }
+                            })
                         },
                     );
+                    $updates.clear();
                 })
             }};
         }
@@ -551,25 +567,23 @@ impl<'a> JoinState<'a> {
                     if binding_info.has_empty_subset(a.atom) {
                         return;
                     }
-
                     let prober = self.get_column_index(plan, binding_info, a.atom, a.column);
                     let table = self.db.tables[plan.atoms[a.atom].table].table.as_ref();
-                    let mut updates = with_pool_set(|ps| {
-                        let mut updates: Pooled<Vec<Pooled<FrameUpdate>>> = ps.get();
+                    let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
+                    with_pool_set(|ps| {
                         prober.for_each(|val, x| {
-                            let mut update: Pooled<FrameUpdate> = ps.get();
-                            update.push_binding(*var, val[0]);
+                            updates.push_binding(*var, val[0]);
                             let sub = refine_subset(x.to_owned(&ps.get_pool()), &[], &table);
                             if sub.is_empty() {
+                                updates.rollback();
                                 return;
                             }
-                            update.refine_atom(a.atom, sub);
-                            updates.push(update);
-                            if updates.len() >= chunk_size {
-                                drain_updates_parallel!(updates);
+                            updates.refine_atom(a.atom, sub);
+                            if updates.frames() >= chunk_size {
+                                drain_updates!(updates);
                             }
-                        });
-                        updates
+                            updates.new_frame();
+                        })
                     });
                     drain_updates!(updates);
                     binding_info.move_back(a.atom, prober);
@@ -580,28 +594,26 @@ impl<'a> JoinState<'a> {
                     }
                     let prober = self.get_column_index(plan, binding_info, a.atom, a.column);
                     let table = self.db.tables[plan.atoms[a.atom].table].table.as_ref();
-                    let mut updates = with_pool_set(|ps| {
-                        let mut updates: Pooled<Vec<Pooled<FrameUpdate>>> = ps.get();
+                    let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
+                    with_pool_set(|ps| {
                         prober.for_each(|val, x| {
-                            let mut update: Pooled<FrameUpdate> = ps.get();
-                            update.push_binding(*var, val[0]);
+                            updates.push_binding(*var, val[0]);
                             let sub = refine_subset(x.to_owned(&ps.get_pool()), &a.cs, &table);
                             if sub.is_empty() {
+                                updates.rollback();
                                 return;
                             }
-                            update.refine_atom(a.atom, sub);
-                            updates.push(update);
-                            if updates.len() >= chunk_size {
-                                drain_updates_parallel!(updates);
+                            updates.refine_atom(a.atom, sub);
+                            if updates.frames() >= chunk_size {
+                                drain_updates!(updates);
                             }
-                        });
-                        updates
+                            updates.new_frame();
+                        })
                     });
                     drain_updates!(updates);
                     binding_info.move_back(a.atom, prober);
                 }),
                 [a, b] => intersect_ab(|| {
-                    let mut updates: Pooled<Vec<Pooled<FrameUpdate>>> = with_pool_set(PoolSet::get);
                     let a_prober = self.get_column_index(plan, binding_info, a.atom, a.column);
                     let b_prober = self.get_column_index(plan, binding_info, b.atom, b.column);
 
@@ -618,11 +630,13 @@ impl<'a> JoinState<'a> {
                     let small_table = self.db.tables[plan.atoms[smaller_atom].table]
                         .table
                         .as_ref();
+                    let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                     with_pool_set(|ps| {
                         smaller.for_each(|val, small_sub| {
                             if let Some(mut large_sub) = larger.get_subset(val) {
                                 large_sub = refine_subset(large_sub, &larger_scan.cs, &large_table);
                                 if large_sub.is_empty() {
+                                    updates.rollback();
                                     return;
                                 }
                                 let small_sub = refine_subset(
@@ -631,14 +645,14 @@ impl<'a> JoinState<'a> {
                                     &small_table,
                                 );
                                 if small_sub.is_empty() {
+                                    updates.rollback();
                                     return;
                                 }
-                                let mut update: Pooled<FrameUpdate> = ps.get();
-                                update.push_binding(*var, val[0]);
-                                update.refine_atom(smaller_atom, small_sub);
-                                update.refine_atom(larger_atom, large_sub);
-                                updates.push(update);
-                                if updates.len() >= chunk_size {
+                                updates.push_binding(*var, val[0]);
+                                updates.refine_atom(smaller_atom, small_sub);
+                                updates.refine_atom(larger_atom, large_sub);
+                                updates.new_frame();
+                                if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
                                 }
                             }
@@ -650,7 +664,6 @@ impl<'a> JoinState<'a> {
                     binding_info.move_back(b.atom, b_prober);
                 }),
                 rest => intersect_rest(|| {
-                    let mut updates: Pooled<Vec<Pooled<FrameUpdate>>> = with_pool_set(PoolSet::get);
                     let mut smallest = 0;
                     let mut smallest_size = usize::MAX;
                     let mut probers = Vec::with_capacity(rest.len());
@@ -672,10 +685,11 @@ impl<'a> JoinState<'a> {
 
                     if smallest_size != 0 {
                         // Smallest leads the scan
+                        let mut updates =
+                            FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                         probers[smallest].for_each(|key, sub| {
                             with_pool_set(|ps| {
-                                let mut update: Pooled<FrameUpdate> = ps.get();
-                                update.push_binding(*var, key[0]);
+                                updates.push_binding(*var, key[0]);
                                 for (i, scan) in rest.iter().enumerate() {
                                     if i == smallest {
                                         continue;
@@ -686,10 +700,12 @@ impl<'a> JoinState<'a> {
                                             .as_ref();
                                         sub = refine_subset(sub, &rest[i].cs, &table);
                                         if sub.is_empty() {
+                                            updates.rollback();
                                             return;
                                         }
-                                        update.refine_atom(scan.atom, sub)
+                                        updates.refine_atom(scan.atom, sub)
                                     } else {
+                                        updates.rollback();
                                         // Empty intersection.
                                         return;
                                     }
@@ -697,11 +713,12 @@ impl<'a> JoinState<'a> {
                                 let sub = sub.to_owned(&ps.get_pool());
                                 let sub = refine_subset(sub, &main_spec.cs, &main_spec_table);
                                 if sub.is_empty() {
+                                    updates.rollback();
                                     return;
                                 }
-                                update.refine_atom(main_spec.atom, sub);
-                                updates.push(update);
-                                if updates.len() >= chunk_size {
+                                updates.refine_atom(main_spec.atom, sub);
+                                updates.new_frame();
+                                if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
                                 }
                             })
@@ -722,12 +739,12 @@ impl<'a> JoinState<'a> {
                 if binding_info.has_empty_subset(cover_atom) {
                     return;
                 }
-                let mut updates: Pooled<Vec<Pooled<FrameUpdate>>> = with_pool_set(PoolSet::get);
                 let proj = SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
                 let cover_node = binding_info.unwrap_val(cover_atom);
                 let cover_subset = cover_node.subset.as_ref();
                 let mut cur = Offset::new(0);
                 let mut buffer = TaggedRowBuffer::new(bind.len());
+                let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                 loop {
                     buffer.clear();
                     let table = &self.db.tables[plan.atoms[cover_atom].table].table;
@@ -740,17 +757,16 @@ impl<'a> JoinState<'a> {
                         &mut buffer,
                     );
                     for (row, key) in buffer.non_stale() {
-                        let mut update: Pooled<FrameUpdate> = with_pool_set(PoolSet::get);
-                        update.refine_atom(
+                        updates.refine_atom(
                             cover_atom,
                             Subset::Dense(OffsetRange::new(row, row.inc())),
                         );
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
-                            update.push_binding(*var, key[i]);
+                            updates.push_binding(*var, key[i]);
                         }
-                        updates.push(update);
-                        if updates.len() >= chunk_size {
+                        updates.new_frame();
+                        if updates.frames() >= chunk_size {
                             drain_updates_parallel!(updates);
                         }
                     }
@@ -789,12 +805,12 @@ impl<'a> JoinState<'a> {
                         )
                     })
                     .collect::<SmallVec<[(usize, AtomId, Prober); 4]>>();
-                let mut updates: Pooled<Vec<Pooled<FrameUpdate>>> = with_pool_set(PoolSet::get);
                 let proj = SmallVec::<[ColumnId; 4]>::from_iter(bind.iter().map(|(col, _)| *col));
                 let cover_node = binding_info.unwrap_val(cover_atom);
                 let cover_subset = cover_node.subset.as_ref();
                 let mut cur = Offset::new(0);
                 let mut buffer = TaggedRowBuffer::new(bind.len());
+                let mut updates = FrameUpdates::with_capacity(cmp::min(chunk_size, cur_size));
                 loop {
                     buffer.clear();
                     let table = &self.db.tables[plan.atoms[cover_atom].table].table;
@@ -806,16 +822,14 @@ impl<'a> JoinState<'a> {
                         &cover.constraints,
                         &mut buffer,
                     );
-                    let pool: Pool<FrameUpdate> = with_pool_set(PoolSet::get_pool);
                     'mid: for (row, key) in buffer.non_stale() {
-                        let mut update: Pooled<FrameUpdate> = pool.get();
-                        update.refine_atom(
+                        updates.refine_atom(
                             cover_atom,
                             Subset::Dense(OffsetRange::new(row, row.inc())),
                         );
                         // bind the values
                         for (i, (_, var)) in bind.iter().enumerate() {
-                            update.push_binding(*var, key[i]);
+                            updates.push_binding(*var, key[i]);
                         }
                         // now probe each remaining indexes
                         for (i, atom, prober) in &index_probers {
@@ -826,6 +840,7 @@ impl<'a> JoinState<'a> {
                                 .map(|col| key[col.index()])
                                 .collect::<SmallVec<[Value; 4]>>();
                             let Some(mut subset) = prober.get_subset(&index_key) else {
+                                updates.rollback();
                                 // There are no possible values for this subset
                                 continue 'mid;
                             };
@@ -834,13 +849,14 @@ impl<'a> JoinState<'a> {
                             let cs = &to_intersect[*i].0.constraints;
                             subset = refine_subset(subset, cs, &table_info.table.as_ref());
                             if subset.is_empty() {
+                                updates.rollback();
                                 // There are no possible values for this subset
                                 continue 'mid;
                             }
-                            update.refine_atom(*atom, subset);
+                            updates.refine_atom(*atom, subset);
                         }
-                        updates.push(update);
-                        if updates.len() >= chunk_size {
+                        updates.new_frame();
+                        if updates.frames() >= chunk_size {
                             drain_updates_parallel!(updates);
                         }
                     }
@@ -862,36 +878,6 @@ impl<'a> JoinState<'a> {
                 }
             }),
         }
-    }
-}
-
-#[derive(Default)]
-pub(crate) struct FrameUpdate {
-    bindings: Vec<(Variable, Value)>,
-    refinements: Vec<(AtomId, Subset)>,
-}
-
-impl FrameUpdate {
-    fn push_binding(&mut self, var: Variable, val: Value) {
-        self.bindings.push((var, val));
-    }
-
-    fn refine_atom(&mut self, atom: AtomId, subset: Subset) {
-        self.refinements.push((atom, subset));
-    }
-}
-
-impl Clear for FrameUpdate {
-    fn clear(&mut self) {
-        self.bindings.clear();
-        self.refinements.clear();
-    }
-    fn reuse(&self) -> bool {
-        self.bindings.capacity() > 0 || self.refinements.capacity() > 0
-    }
-    fn bytes(&self) -> usize {
-        self.bindings.capacity() * mem::size_of::<(Variable, Value)>()
-            + self.refinements.capacity() * mem::size_of::<(AtomId, Subset)>()
     }
 }
 
@@ -923,15 +909,16 @@ trait ActionBuffer<'state>: Send {
     /// Execute `work`, potentially asynchronously, with a mutable reference to
     /// an action buffer, potentially handed off to a different thread.
     ///
-    /// Callers pass a clonable `LocalN` values that may be modified by work, or
+    /// Callers [`BorrowedLocalState`] values that may be modified by work, or
     /// cloned first and then have a separate copy modified by `work`. Callers
     /// should assume that `local` _is_ modified synchronously.
-    fn recur<Local1: Clone + Send + 'state, Local2: Clone + Send + 'state>(
+    // NB: Earlier versions of this method had BorrowedLocalState be a generic instead, but this
+    // ran into difficulties when we needed to pass multiple mutable references.
+    fn recur<'local>(
         &mut self,
-        local1: &mut Local1,
-        local2: &mut Local2,
+        local: BorrowedLocalState<'local>,
         to_exec_state: impl FnMut() -> ExecutionState<'state> + Send + 'state,
-        work: impl for<'a> FnOnce(&mut Local1, &mut Local2, &mut Self::AsLocal<'a>) + Send + 'state,
+        work: impl for<'a> FnOnce(BorrowedLocalState<'a>, &mut Self::AsLocal<'a>) + Send + 'state,
     );
 
     /// The unit at which you should batch updates passed to calls to `recur`,
@@ -985,14 +972,14 @@ impl<'a, 'outer: 'a> ActionBuffer<'a> for InPlaceActionBuffer<'outer> {
             self.match_counter,
         );
     }
-    fn recur<Local1: Clone + Send + 'a, Local2: Clone + Send + 'a>(
+
+    fn recur<'local>(
         &mut self,
-        l1: &mut Local1,
-        l2: &mut Local2,
+        local: BorrowedLocalState<'local>,
         _to_exec_state: impl FnMut() -> ExecutionState<'a> + Send + 'a,
-        work: impl for<'b> FnOnce(&mut Local1, &mut Local2, &mut Self) + Send + 'a,
+        work: impl for<'b> FnOnce(BorrowedLocalState<'b>, &mut Self) + Send + 'a,
     ) {
-        work(l1, l2, self);
+        work(local, self)
     }
 }
 
@@ -1058,19 +1045,17 @@ impl<'scope> ActionBuffer<'scope> for ScopedActionBuffer<'_, 'scope> {
         );
         self.needs_flush = false;
     }
-    fn recur<Local1: Clone + Send + 'scope, Local2: Clone + Send + 'scope>(
+    fn recur<'local>(
         &mut self,
-        l1: &mut Local1,
-        l2: &mut Local2,
+        mut local: BorrowedLocalState<'local>,
         mut to_exec_state: impl FnMut() -> ExecutionState<'scope> + Send + 'scope,
-        work: impl for<'a> FnOnce(&mut Local1, &mut Local2, &mut ScopedActionBuffer<'a, 'scope>)
+        work: impl for<'a> FnOnce(BorrowedLocalState<'a>, &mut ScopedActionBuffer<'a, 'scope>)
             + Send
             + 'scope,
     ) {
         let rule_set = self.rule_set;
         let match_counter = self.match_counter;
-        let mut inner1 = l1.clone();
-        let mut inner2 = l2.clone();
+        let mut inner = local.clone_state();
         self.scope.spawn(move |scope| {
             let mut buf: ScopedActionBuffer<'_, 'scope> = ScopedActionBuffer {
                 scope,
@@ -1079,7 +1064,7 @@ impl<'scope> ActionBuffer<'scope> for ScopedActionBuffer<'_, 'scope> {
                 needs_flush: false,
                 batches: Default::default(),
             };
-            work(&mut inner1, &mut inner2, &mut buf);
+            work(inner.borrow_mut(), &mut buf);
             if buf.needs_flush {
                 flush_action_states(
                     &mut to_exec_state(),
@@ -1090,6 +1075,7 @@ impl<'scope> ActionBuffer<'scope> for ScopedActionBuffer<'_, 'scope> {
             }
         });
     }
+
     fn morsel_size(&mut self, _level: usize, _total: usize) -> usize {
         // Lower morsel size to increase parallelism.
         match _level {
@@ -1197,9 +1183,41 @@ impl InstrOrder {
     }
 }
 
+struct BorrowedLocalState<'a> {
+    instr_order: &'a mut InstrOrder,
+    binding_info: &'a mut BindingInfo,
+    updates: &'a mut FrameUpdates,
+}
+
+impl BorrowedLocalState<'_> {
+    fn clone_state(&mut self) -> LocalState {
+        LocalState {
+            instr_order: self.instr_order.clone(),
+            binding_info: self.binding_info.clone(),
+            updates: std::mem::take(self.updates),
+        }
+    }
+}
+
+struct LocalState {
+    instr_order: InstrOrder,
+    binding_info: BindingInfo,
+    updates: FrameUpdates,
+}
+
+impl LocalState {
+    fn borrow_mut<'a>(&'a mut self) -> BorrowedLocalState<'a> {
+        BorrowedLocalState {
+            instr_order: &mut self.instr_order,
+            binding_info: &mut self.binding_info,
+            updates: &mut self.updates,
+        }
+    }
+}
+
 macro_rules! frame_func {
     ($name:ident) => {
-        #[inline(never)]
+        #[inline(always)]
         pub(crate) fn $name<R>(f: impl FnOnce() -> R) -> R {
             f()
         }

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -473,7 +473,7 @@ impl<'a> JoinState<'a> {
         }
         let chunk_size = action_buf.morsel_size(cur, instr_order.len());
         let mut cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);
-        if cur_size > 32 && cur_size % 2 == 1 && cur < instr_order.len() - 1 {
+        if cur_size > 32 && cur_size % 3 == 1 && cur < instr_order.len() - 1 {
             // If we have a reasonable number of tuples to process, adjust the variable order.
             sort_plan_by_size(instr_order, cur, &plan.stages.instrs, binding_info);
             cur_size = estimate_size(&plan.stages.instrs[instr_order.get(cur)], binding_info);

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 use web_time::Instant;
 
 use crate::{
-    action::{Bindings, ExecutionState, PredictedVals},
+    action::{Bindings, BufferedBindings, ExecutionState, PredictedVals},
     common::{DashMap, Value},
     free_join::{
         frame_update::{FrameUpdates, UpdateInstr},
@@ -579,7 +579,7 @@ impl<'a> JoinState<'a> {
                                 return;
                             }
                             updates.refine_atom(a.atom, sub);
-                            updates.new_frame();
+                            updates.finish_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
                             }
@@ -604,7 +604,7 @@ impl<'a> JoinState<'a> {
                                 return;
                             }
                             updates.refine_atom(a.atom, sub);
-                            updates.new_frame();
+                            updates.finish_frame();
                             if updates.frames() >= chunk_size {
                                 drain_updates!(updates);
                             }
@@ -651,7 +651,7 @@ impl<'a> JoinState<'a> {
                                 updates.push_binding(*var, val[0]);
                                 updates.refine_atom(smaller_atom, small_sub);
                                 updates.refine_atom(larger_atom, large_sub);
-                                updates.new_frame();
+                                updates.finish_frame();
                                 if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
                                 }
@@ -717,7 +717,7 @@ impl<'a> JoinState<'a> {
                                     return;
                                 }
                                 updates.refine_atom(main_spec.atom, sub);
-                                updates.new_frame();
+                                updates.finish_frame();
                                 if updates.frames() >= chunk_size {
                                     drain_updates_parallel!(updates);
                                 }
@@ -765,7 +765,7 @@ impl<'a> JoinState<'a> {
                         for (i, (_, var)) in bind.iter().enumerate() {
                             updates.push_binding(*var, key[i]);
                         }
-                        updates.new_frame();
+                        updates.finish_frame();
                         if updates.frames() >= chunk_size {
                             drain_updates_parallel!(updates);
                         }
@@ -855,7 +855,7 @@ impl<'a> JoinState<'a> {
                             }
                             updates.refine_atom(*atom, subset);
                         }
-                        updates.new_frame();
+                        updates.finish_frame();
                         if updates.frames() >= chunk_size {
                             drain_updates_parallel!(updates);
                         }
@@ -927,7 +927,7 @@ trait ActionBuffer<'state>: Send {
     /// As of right now this is just a hard-coded value. We may change it in the
     /// future to fan out more at higher levels though.
     fn morsel_size(&mut self, _level: usize, _total: usize) -> usize {
-        1024
+        256
     }
 }
 

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 use web_time::Instant;
 
 use crate::{
-    action::{Bindings, BufferedBindings, ExecutionState, PredictedVals},
+    action::{Bindings, ExecutionState, PredictedVals},
     common::{DashMap, Value},
     free_join::{
         frame_update::{FrameUpdates, UpdateInstr},

--- a/core-relations/src/free_join/execute.rs
+++ b/core-relations/src/free_join/execute.rs
@@ -465,7 +465,6 @@ impl<'a> JoinState<'a> {
     ) where
         'a: 'buf,
     {
-        let remove_all_inline_never = 1;
         if cur >= instr_order.len() {
             action_buf.push_bindings(plan.stages.actions, &binding_info.bindings, || {
                 ExecutionState::new(self.preds, self.db.read_only_view(), Default::default())

--- a/core-relations/src/free_join/frame_update.rs
+++ b/core-relations/src/free_join/frame_update.rs
@@ -1,0 +1,90 @@
+//! A data-structure for low-overhead buffering of updates in a free join
+//! execution.
+
+use numeric_id::{define_id, DenseIdMap};
+
+use crate::{Subset, Value};
+
+use super::{AtomId, Variable};
+
+define_id!(pub SubsetId, u32, "An offset into a buffer of subsets");
+
+enum UpdateCell {
+    PushBinding(Variable, Value),
+    RefineAtom(AtomId, SubsetId),
+    EndFrame,
+}
+
+pub(super) enum UpdateInstr {
+    PushBinding(Variable, Value),
+    RefineAtom(AtomId, Subset),
+    EndFrame,
+}
+
+#[derive(Default)]
+pub(super) struct FrameUpdates {
+    subsets: DenseIdMap<SubsetId, Subset>,
+    updates: Vec<UpdateCell>,
+    frames: usize,
+    last_start: usize,
+}
+
+impl FrameUpdates {
+    pub(super) fn with_capacity(capacity: usize) -> FrameUpdates {
+        FrameUpdates {
+            subsets: DenseIdMap::with_capacity(capacity),
+            updates: Vec::with_capacity(capacity * 2),
+            frames: 0,
+            last_start: 0,
+        }
+    }
+
+    pub(super) fn push_binding(&mut self, var: Variable, val: Value) {
+        self.updates.push(UpdateCell::PushBinding(var, val));
+    }
+
+    pub(super) fn refine_atom(&mut self, atom: AtomId, subset: Subset) {
+        let subset = self.subsets.push(subset);
+        self.updates.push(UpdateCell::RefineAtom(atom, subset));
+    }
+
+    pub(super) fn rollback(&mut self) {
+        self.updates.truncate(self.last_start);
+    }
+
+    pub(super) fn new_frame(&mut self) {
+        self.updates.push(UpdateCell::EndFrame);
+        self.last_start = self.updates.len();
+        self.frames += 1;
+    }
+
+    pub(super) fn frames(&self) -> usize {
+        self.frames
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.subsets.clear();
+        self.updates.clear();
+    }
+
+    pub(super) fn drain(&mut self, f: impl FnMut(UpdateInstr)) {
+        let start = if matches!(self.updates.first(), Some(UpdateCell::EndFrame)) {
+            1 // Skip the first EndFrame
+        } else {
+            0
+        };
+        self.updates
+            .drain(start..)
+            .map(|cell| match cell {
+                UpdateCell::PushBinding(var, val) => UpdateInstr::PushBinding(var, val),
+                UpdateCell::RefineAtom(atom, subset) => {
+                    UpdateInstr::RefineAtom(atom, self.subsets.take(subset).unwrap())
+                }
+                UpdateCell::EndFrame => UpdateInstr::EndFrame,
+            })
+            .for_each(f);
+        self.subsets.clear();
+        self.frames = 0;
+        self.last_start = 0;
+    }
+}

--- a/core-relations/src/free_join/frame_update.rs
+++ b/core-relations/src/free_join/frame_update.rs
@@ -1,5 +1,16 @@
 //! A data-structure for low-overhead buffering of updates in a free join
 //! execution.
+//!
+//! Free Join is a recursive algorithm that that discovers a candidate binding for a particular
+//! variable in a query and then recursively runs the rest of the join restricted for that binding
+//! holding. Once the "sub-join" finishes, the outer recursive call backtracks, adds a separate
+//! binding, and then repeats.
+//!
+//! The Free Join paper observed that this resulted in poor cache behavior because for every cell
+//! iterated over in an outer stage, we had to do several other steps on successive inner stages.
+//! Instead, we can accumulate a set of new bindings in a separate buffer and then iterate over
+//! those bindings in recursive calls. When parallelism is enabled, this data-structure allows us
+//! hand over an entire batch of recursive calls to a separate thread to process independently.
 
 use numeric_id::{define_id, DenseIdMap};
 

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -103,6 +103,7 @@ pub(crate) struct VarInfo {
     /// Whether or not this variable shows up in the "actions" portion of a
     /// rule.
     pub(crate) used_in_rhs: bool,
+    pub(crate) defined_in_rhs: bool,
 }
 
 pub(crate) type HashIndex = Arc<ResettableOnceLock<Index<TupleIndex>>>;

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -35,6 +35,7 @@ use self::plan::Plan;
 use crate::action::{ExecutionState, PredictedVals};
 
 pub(crate) mod execute;
+pub(crate) mod frame_update;
 pub(crate) mod plan;
 
 define_id!(

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -247,7 +247,7 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
                 )
                 .fill_vec(&mut out, Value::stale, |_, args| self.invoke(state, &args)),
         }
-        bindings.insert(out_var, out);
+        bindings.insert(out_var, &out);
     }
 
     /// A variant of [`ExternalFunctionExt::invoke_batch`] that overwrites the output variable,
@@ -265,9 +265,7 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
         out_var: Variable,
     ) {
         let pool: Pool<Vec<Value>> = with_pool_set(|ps| ps.get_pool().clone());
-        let mut out = bindings
-            .take(out_var)
-            .expect("output variable must be bound");
+        let mut out = bindings.take(out_var).expect("out_var must be bound");
         mask.iter_dynamic(
             pool,
             args.iter().map(|v| match v {
@@ -275,8 +273,8 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
                 QueryEntry::Const(c) => ValueSource::Const(*c),
             }),
         )
-        .assign_vec_and_retain(&mut out, |_, args| self.invoke(state, &args));
-        bindings.insert(out_var, out);
+        .assign_vec_and_retain(&mut out.vals, |_, args| self.invoke(state, &args));
+        bindings.replace(out);
     }
 }
 

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -306,7 +306,7 @@ impl Database {
     }
 
     /// Initialize a new rulse set to run against this database.
-    pub fn new_rule_set(&mut self) -> RuleSetBuilder {
+    pub fn new_rule_set(&mut self) -> RuleSetBuilder<'_> {
         RuleSetBuilder::new(self)
     }
 
@@ -400,7 +400,7 @@ impl Database {
         f(&mut state)
     }
 
-    pub(crate) fn read_only_view(&self) -> DbView {
+    pub(crate) fn read_only_view(&self) -> DbView<'_> {
         DbView {
             table_info: &self.tables,
             counters: &self.counters,

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -192,14 +192,61 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
         let pool: Pool<Vec<Value>> = with_pool_set(|ps| ps.get_pool().clone());
         let mut out = pool.get();
         out.reserve(mask.len());
-        mask.iter_dynamic(
-            pool,
-            args.iter().map(|v| match v {
-                QueryEntry::Var(v) => ValueSource::Slice(&bindings[*v]),
-                QueryEntry::Const(c) => ValueSource::Const(*c),
-            }),
-        )
-        .fill_vec(&mut out, Value::stale, |_, args| self.invoke(state, &args));
+
+        match args {
+            [] => {
+                mask.empty_iter()
+                    .fill_vec(&mut out, Value::stale, |_, _| self.invoke(state, &[]));
+            }
+            [QueryEntry::Var(v)] => {
+                mask.iter(&bindings[*v])
+                    .fill_vec(&mut out, Value::stale, |_, arg| {
+                        self.invoke(state, std::slice::from_ref(arg))
+                    });
+            }
+            [QueryEntry::Const(c)] => {
+                mask.empty_iter().fill_vec(&mut out, Value::stale, |_, _| {
+                    self.invoke(state, std::slice::from_ref(c))
+                });
+            }
+            [QueryEntry::Var(v1), QueryEntry::Var(v2)] => {
+                mask.iter(&bindings[*v1]).zip(&bindings[*v2]).fill_vec(
+                    &mut out,
+                    Value::stale,
+                    |_, (v1, v2)| self.invoke(state, &[*v1, *v2]),
+                );
+            }
+            [QueryEntry::Const(c1), QueryEntry::Const(c2)] => {
+                mask.empty_iter().fill_vec(&mut out, Value::stale, |_, _| {
+                    self.invoke(state, &[*c1, *c2])
+                });
+            }
+            [QueryEntry::Var(v), QueryEntry::Const(c)] => {
+                mask.iter(&bindings[*v])
+                    .fill_vec(&mut out, Value::stale, |_, v| self.invoke(state, &[*v, *c]));
+            }
+            [QueryEntry::Const(c), QueryEntry::Var(v)] => {
+                mask.iter(&bindings[*v])
+                    .fill_vec(&mut out, Value::stale, |_, v| self.invoke(state, &[*c, *v]));
+            }
+            [QueryEntry::Var(v1), QueryEntry::Var(v2), QueryEntry::Var(v3)] => {
+                mask.iter(&bindings[*v1])
+                    .zip(&bindings[*v2])
+                    .zip(&bindings[*v3])
+                    .fill_vec(&mut out, Value::stale, |_, ((v1, v2), v3)| {
+                        self.invoke(state, &[*v1, *v2, *v3])
+                    });
+            }
+            _ => mask
+                .iter_dynamic(
+                    pool,
+                    args.iter().map(|v| match v {
+                        QueryEntry::Var(v) => ValueSource::Slice(&bindings[*v]),
+                        QueryEntry::Const(c) => ValueSource::Const(*c),
+                    }),
+                )
+                .fill_vec(&mut out, Value::stale, |_, args| self.invoke(state, &args)),
+        }
         bindings.insert(out_var, out);
     }
 

--- a/core-relations/src/free_join/mod.rs
+++ b/core-relations/src/free_join/mod.rs
@@ -194,7 +194,7 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
         let pool: Pool<Vec<Value>> = with_pool_set(|ps| ps.get_pool().clone());
         let mut out = pool.get();
         out.reserve(mask.len());
-        process_vec!(mask, args, bindings, |iter| {
+        for_each_binding_with_mask!(mask, args, bindings, |iter| {
             iter.fill_vec(&mut out, Value::stale, |_, args| {
                 self.invoke(state, args.as_slice())
             });
@@ -217,7 +217,7 @@ pub(crate) trait ExternalFunctionExt: ExternalFunction {
         out_var: Variable,
     ) {
         let mut out = bindings.take(out_var).expect("out_var must be bound");
-        process_vec!(mask, args, bindings, |iter| {
+        for_each_binding_with_mask!(mask, args, bindings, |iter| {
             iter.assign_vec_and_retain(&mut out.vals, |_, args| self.invoke(state, &args))
         });
         bindings.replace(out);

--- a/core-relations/src/hash_index/mod.rs
+++ b/core-relations/src/hash_index/mod.rs
@@ -149,7 +149,7 @@ pub(crate) trait IndexBase {
     /// Remove any existing entries in the index.
     fn clear(&mut self);
     /// Get the subset corresponding to this key, if there is one.
-    fn get_subset(&self, key: &Self::Key) -> Option<SubsetRef>;
+    fn get_subset(&self, key: &Self::Key) -> Option<SubsetRef<'_>>;
     /// Add the given key and row id to the table.
     fn add_row(&mut self, key: &Self::WriteKey, row: RowId);
     /// Merge the contents of the [`TaggedRowBuffer`] into the table.

--- a/core-relations/src/lib.rs
+++ b/core-relations/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 #[cfg(test)]
 pub(crate) mod table_shortcuts;
+#[macro_use]
 pub(crate) mod action;
 pub(crate) mod base_values;
 pub(crate) mod common;

--- a/core-relations/src/offsets/mod.rs
+++ b/core-relations/src/offsets/mod.rs
@@ -336,7 +336,7 @@ impl Subset {
         matches!(self, Subset::Dense(_))
     }
 
-    pub fn as_ref(&self) -> SubsetRef {
+    pub fn as_ref(&self) -> SubsetRef<'_> {
         match self {
             Subset::Dense(r) => SubsetRef::Dense(*r),
             Subset::Sparse(s) => SubsetRef::Sparse(s.slice()),

--- a/core-relations/src/pool/mod.rs
+++ b/core-relations/src/pool/mod.rs
@@ -17,7 +17,6 @@ use numeric_id::{DenseIdMap, IdVec};
 use crate::{
     action::{Instr, PredictedVals},
     common::{HashMap, HashSet, IndexMap, IndexSet, ShardId, Value},
-    free_join::execute::FrameUpdate,
     hash_index::{BufferedSubset, ColumnIndex, TableEntry},
     offsets::SortedOffsetVector,
     table::TableEntry as SwTableEntry,
@@ -430,8 +429,6 @@ pool_set! {
         constraints: Vec<Constraint> [ 1 << 20 ],
         bitsets: FixedBitSet [ 1 << 20 ],
         instrs: Vec<Instr> [ 1 << 20 ],
-        frame_updates: FrameUpdate [ 1 << 25 ],
-        frame_update_vecs: Vec<Pooled<FrameUpdate>> [ 1 << 20 ],
         tuple_indexes: HashTable<TableEntry<BufferedSubset>> [ 1 << 20 ],
         staged_outputs: HashTable<SwTableEntry> [ 1 << 25 ],
         predicted_vals: PredictedVals [ 1 << 20 ],

--- a/core-relations/src/query.rs
+++ b/core-relations/src/query.rs
@@ -212,6 +212,7 @@ impl<'outer, 'a> QueryBuilder<'outer, 'a> {
     }
 
     fn mark_defined(&mut self, entry: &QueryEntry) {
+        // TODO: use some of this information in query planning, e.g. dedup at match time.
         if let QueryEntry::Var(v) = entry {
             self.query.var_info[*v].defined_in_rhs = true;
         }

--- a/core-relations/src/query.rs
+++ b/core-relations/src/query.rs
@@ -3,6 +3,7 @@
 use std::{iter::once, sync::Arc};
 
 use numeric_id::{define_id, DenseIdMap, IdVec, NumericId};
+use smallvec::SmallVec;
 use thiserror::Error;
 
 use crate::{
@@ -24,7 +25,13 @@ define_id!(pub RuleId, u32, "An identifier for a rule in a rule set");
 pub struct CachedPlan {
     plan: Plan,
     desc: String,
-    actions: Arc<Pooled<Vec<Instr>>>,
+    actions: ActionInfo,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ActionInfo {
+    pub(crate) used_vars: SmallVec<[Variable; 4]>,
+    pub(crate) instrs: Arc<Pooled<Vec<Instr>>>,
 }
 
 /// A set of rules to run against a [`Database`].
@@ -40,7 +47,7 @@ pub struct RuleSet {
     /// later on, most of the core logic would still work but the accounting logic could get more
     /// complex.
     pub(crate) plans: IdVec<RuleId, (Plan, String /* description */, ActionId)>,
-    pub(crate) actions: DenseIdMap<ActionId, Arc<Pooled<Vec<Instr>>>>,
+    pub(crate) actions: DenseIdMap<ActionId, ActionInfo>,
 }
 
 impl RuleSet {
@@ -192,6 +199,7 @@ impl<'outer, 'a> QueryBuilder<'outer, 'a> {
         self.query.var_info.push(VarInfo {
             occurrences: Default::default(),
             used_in_rhs: false,
+            defined_in_rhs: false,
         })
     }
 
@@ -200,6 +208,12 @@ impl<'outer, 'a> QueryBuilder<'outer, 'a> {
             if let QueryEntry::Var(v) = entry {
                 self.query.var_info[*v].used_in_rhs = true;
             }
+        }
+    }
+
+    fn mark_defined(&mut self, entry: &QueryEntry) {
+        if let QueryEntry::Var(v) = entry {
+            self.query.var_info[*v].defined_in_rhs = true;
         }
     }
 
@@ -370,7 +384,18 @@ impl RuleBuilder<'_, '_> {
     }
     pub fn build_with_description(mut self, desc: impl Into<String>) -> RuleId {
         // Generate an id for our actions and slot them in.
-        let action_id = self.qb.rsb.rule_set.actions.push(Arc::new(self.qb.instrs));
+        let used_vars =
+            SmallVec::from_iter(self.qb.query.var_info.iter().filter_map(|(v, info)| {
+                if info.used_in_rhs && !info.defined_in_rhs {
+                    Some(v)
+                } else {
+                    None
+                }
+            }));
+        let action_id = self.qb.rsb.rule_set.actions.push(ActionInfo {
+            instrs: Arc::new(self.qb.instrs),
+            used_vars,
+        });
         self.qb.query.action = action_id;
         // Plan the query
         let plan = self.qb.rsb.db.plan_query(self.qb.query);
@@ -386,6 +411,7 @@ impl RuleBuilder<'_, '_> {
     pub fn read_counter(&mut self, counter: CounterId) -> Variable {
         let dst = self.qb.new_var();
         self.qb.instrs.push(Instr::ReadCounter { counter, dst });
+        self.qb.mark_defined(&dst.into());
         dst
     }
 
@@ -425,6 +451,7 @@ impl RuleBuilder<'_, '_> {
                 WriteVal::QueryEntry(qe) => Some(qe),
                 WriteVal::IncCounter(_) | WriteVal::CurrentVal(_) => None,
             }));
+        self.qb.mark_defined(&res.into());
         Ok(res)
     }
 
@@ -459,6 +486,7 @@ impl RuleBuilder<'_, '_> {
         });
         self.qb.mark_used(args);
         self.qb.mark_used(&[default]);
+        self.qb.mark_defined(&res.into());
         Ok(res)
     }
 
@@ -490,6 +518,7 @@ impl RuleBuilder<'_, '_> {
             dst_var: res,
         });
         self.qb.mark_used(args);
+        self.qb.mark_defined(&res.into());
         Ok(res)
     }
 
@@ -569,6 +598,7 @@ impl RuleBuilder<'_, '_> {
             dst: res,
         });
         self.qb.mark_used(args);
+        self.qb.mark_defined(&res.into());
         Ok(res)
     }
 
@@ -602,6 +632,7 @@ impl RuleBuilder<'_, '_> {
         });
         self.qb.mark_used(key);
         self.qb.mark_used(func_args);
+        self.qb.mark_defined(&res.into());
         Ok(res)
     }
 
@@ -622,6 +653,7 @@ impl RuleBuilder<'_, '_> {
         });
         self.qb.mark_used(args1);
         self.qb.mark_used(args2);
+        self.qb.mark_defined(&res.into());
         Ok(res)
     }
 

--- a/core-relations/src/row_buffer/mod.rs
+++ b/core-relations/src/row_buffer/mod.rs
@@ -413,7 +413,7 @@ pub(crate) struct ParallelRowBufWriter {
 }
 
 impl ParallelRowBufWriter {
-    pub(crate) fn read_handle(&self) -> ReadHandle<impl Deref<Target = [Cell<Value>]> + '_> {
+    pub(crate) fn read_handle(&self) -> ReadHandle<'_, impl Deref<Target = [Cell<Value>]> + '_> {
         ReadHandle {
             buf: &self.buf,
             data: self.vec.as_ref().unwrap().read_access(),

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -6,7 +6,6 @@
 
 use std::{
     any::Any,
-    iter,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
@@ -458,42 +457,11 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
     ) {
         let table = table.as_any().downcast_ref::<T>().unwrap();
         let mut out = with_pool_set(PoolSet::get::<Vec<Value>>);
-        match args {
-            [QueryEntry::Var(v)] => {
-                mask.iter(&bindings[*v])
-                    .fill_vec(&mut out, Value::stale, |_, arg| {
-                        table.get_row_column(&[*arg], col)
-                    });
-            }
-            [QueryEntry::Var(v1), QueryEntry::Var(v2)] => {
-                mask.iter(&bindings[*v1]).zip(&bindings[*v2]).fill_vec(
-                    &mut out,
-                    Value::stale,
-                    |_, (a1, a2)| table.get_row_column(&[*a1, *a2], col),
-                );
-            }
-            [QueryEntry::Var(v1), QueryEntry::Var(v2), QueryEntry::Var(v3)] => {
-                mask.iter(&bindings[*v1])
-                    .zip(&bindings[*v2])
-                    .zip(&bindings[*v3])
-                    .fill_vec(&mut out, Value::stale, |_, ((a1, a2), a3)| {
-                        table.get_row_column(&[*a1, *a2, *a3], col)
-                    });
-            }
-            args => {
-                let pool = with_pool_set(|ps| ps.get_pool().clone());
-                mask.iter_dynamic(
-                    pool,
-                    args.iter().map(|v| match v {
-                        QueryEntry::Var(v) => ValueSource::Slice(&bindings[*v]),
-                        QueryEntry::Const(c) => ValueSource::Const(*c),
-                    }),
-                )
-                .fill_vec(&mut out, Value::stale, |_, args| {
-                    table.get_row_column(&args, col)
-                });
-            }
-        };
+        process_vec!(mask, args, bindings, |iter| {
+            iter.fill_vec(&mut out, Value::stale, |_, args| {
+                table.get_row_column(args.as_slice(), col)
+            })
+        });
         bindings.insert(out_var, &out);
     }
 
@@ -509,51 +477,28 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
     ) {
         let table = table.as_any().downcast_ref::<T>().unwrap();
         let mut out = with_pool_set(|ps| ps.get::<Vec<Value>>());
-        match (args, default) {
-            ([QueryEntry::Var(v)], QueryEntry::Var(default)) => mask
-                .iter(&bindings[*v])
-                .zip(&bindings[default])
-                .fill_vec(&mut out, Value::stale, |_, (v, default)| {
-                    Some(table.get_row_column(&[*v], col).unwrap_or(*default))
-                }),
-            ([QueryEntry::Var(v1), QueryEntry::Var(v2)], QueryEntry::Var(default)) => mask
-                .iter(&bindings[*v1])
-                .zip(&bindings[*v2])
-                .zip(&bindings[default])
-                .fill_vec(&mut out, Value::stale, |_, ((a1, a2), default)| {
-                    Some(table.get_row_column(&[*a1, *a2], col).unwrap_or(*default))
-                }),
-            (
-                [QueryEntry::Var(v1), QueryEntry::Var(v2), QueryEntry::Var(v3)],
-                QueryEntry::Var(default),
-            ) => mask
-                .iter(&bindings[*v1])
-                .zip(&bindings[*v2])
-                .zip(&bindings[*v3])
-                .zip(&bindings[default])
-                .fill_vec(&mut out, Value::stale, |_, (((a1, a2), a3), default)| {
+        process_vec!(mask, args, bindings, |iter| {
+            match default {
+                QueryEntry::Var(default) => iter.zip(&bindings[default]).fill_vec(
+                    &mut out,
+                    Value::stale,
+                    |_, (args, default)| {
+                        Some(
+                            table
+                                .get_row_column(args.as_slice(), col)
+                                .unwrap_or(*default),
+                        )
+                    },
+                ),
+                QueryEntry::Const(default) => iter.fill_vec(&mut out, Value::stale, |_, args| {
                     Some(
                         table
-                            .get_row_column(&[*a1, *a2, *a3], col)
-                            .unwrap_or(*default),
+                            .get_row_column(args.as_slice(), col)
+                            .unwrap_or(default),
                     )
                 }),
-            (args, default) => {
-                let pool = with_pool_set(|ps| ps.get_pool().clone());
-                mask.iter_dynamic(
-                    pool,
-                    iter::once(&default).chain(args.iter()).map(|v| match v {
-                        QueryEntry::Var(v) => ValueSource::Slice(&bindings[*v]),
-                        QueryEntry::Const(c) => ValueSource::Const(*c),
-                    }),
-                )
-                .fill_vec(&mut out, Value::stale, |_, vals| {
-                    let default = vals[0];
-                    let key = &vals[1..];
-                    Some(table.get_row_column(key, col).unwrap_or(default))
-                })
             }
-        };
+        });
         bindings.insert(out_var, &out);
     }
 }

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -494,7 +494,7 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
                 });
             }
         };
-        bindings.insert(out_var, out);
+        bindings.insert(out_var, &out);
     }
 
     fn lookup_with_default_vectorized(
@@ -554,7 +554,7 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
                 })
             }
         };
-        bindings.insert(out_var, out);
+        bindings.insert(out_var, &out);
     }
 }
 

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -457,7 +457,7 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
     ) {
         let table = table.as_any().downcast_ref::<T>().unwrap();
         let mut out = with_pool_set(PoolSet::get::<Vec<Value>>);
-        process_vec!(mask, args, bindings, |iter| {
+        for_each_binding_with_mask!(mask, args, bindings, |iter| {
             iter.fill_vec(&mut out, Value::stale, |_, args| {
                 table.get_row_column(args.as_slice(), col)
             })
@@ -477,7 +477,7 @@ impl<T: Table> TableWrapper for WrapperImpl<T> {
     ) {
         let table = table.as_any().downcast_ref::<T>().unwrap();
         let mut out = with_pool_set(|ps| ps.get::<Vec<Value>>());
-        process_vec!(mask, args, bindings, |iter| {
+        for_each_binding_with_mask!(mask, args, bindings, |iter| {
             match default {
                 QueryEntry::Var(default) => iter.zip(&bindings[default]).fill_vec(
                     &mut out,

--- a/core-relations/src/table_spec.rs
+++ b/core-relations/src/table_spec.rs
@@ -530,7 +530,7 @@ impl WrappedTable {
         }
     }
 
-    pub(crate) fn as_ref(&self) -> WrappedTableRef {
+    pub(crate) fn as_ref(&self) -> WrappedTableRef<'_> {
         WrappedTableRef {
             inner: &*self.inner,
             wrapper: &*self.wrapper,

--- a/core-relations/src/tests.rs
+++ b/core-relations/src/tests.rs
@@ -964,7 +964,7 @@ fn lookup_with_fallback_partial_success() {
     };
     let assert_even = db.add_external_function(make_external_func(|_, args| {
         let [x] = args else { panic!() };
-        if x.rep() % 2 == 0 {
+        if x.rep().is_multiple_of(2) {
             Some(*x)
         } else {
             None
@@ -1048,7 +1048,7 @@ fn call_external_with_fallback() {
     db.merge_all();
     let assert_even = db.add_external_function(make_external_func(|_, args| {
         let [x] = args else { panic!() };
-        if x.rep() % 2 == 0 {
+        if x.rep().is_multiple_of(2) {
             Some(*x)
         } else {
             None

--- a/egglog-bridge/Cargo.toml
+++ b/egglog-bridge/Cargo.toml
@@ -20,9 +20,6 @@ rayon = "1.10.0"
 dyn-clone = "1.0.17"
 once_cell = "1.21.3"
 
-[features]
-serial_examples = []
-
 [dev-dependencies]
 env_logger = "0.11"
 mimalloc = "0.1"

--- a/egglog-bridge/examples/ac.rs
+++ b/egglog-bridge/examples/ac.rs
@@ -9,20 +9,6 @@ static GLOBAL: MiMalloc = MiMalloc;
 fn main() {
     const N: usize = 13;
     env_logger::init();
-    #[cfg(feature = "serial_examples")]
-    {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build_global()
-            .unwrap();
-    }
-    #[cfg(not(feature = "serial_examples"))]
-    {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(16)
-            .build_global()
-            .unwrap();
-    }
 
     for _ in 0..2 {
         let start = web_time::Instant::now();

--- a/egglog-bridge/examples/ac_tracing.rs
+++ b/egglog-bridge/examples/ac_tracing.rs
@@ -5,13 +5,6 @@ use egglog_bridge::{define_rule, ColumnTy, DefaultVal, EGraph, FunctionConfig, M
 fn main() {
     const N: usize = 12;
     env_logger::init();
-    #[cfg(feature = "serial_examples")]
-    {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build_global()
-            .unwrap();
-    }
     let mut egraph = EGraph::with_tracing();
     let int_base = egraph.base_values_mut().register_type::<i64>();
     let num_table = egraph.add_table(FunctionConfig {

--- a/egglog-bridge/examples/math.rs
+++ b/egglog-bridge/examples/math.rs
@@ -11,20 +11,6 @@ static GLOBAL: MiMalloc = MiMalloc;
 #[allow(clippy::disallowed_macros)]
 fn main() {
     env_logger::init();
-    #[cfg(feature = "serial_examples")]
-    {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .build_global()
-            .unwrap();
-    }
-    #[cfg(not(feature = "serial_examples"))]
-    {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(16)
-            .build_global()
-            .unwrap();
-    }
     for _ in 0..2 {
         let start = Instant::now();
         const N: usize = 12;

--- a/egglog-bridge/src/rule.rs
+++ b/egglog-bridge/src/rule.rs
@@ -158,7 +158,7 @@ pub struct RuleBuilder<'a> {
 impl EGraph {
     /// Add a rewrite rule for this [`EGraph`] using a [`RuleBuilder`].
     /// If you aren't sure, use `egraph.new_rule("", true)`.
-    pub fn new_rule(&mut self, desc: &str, seminaive: bool) -> RuleBuilder {
+    pub fn new_rule(&mut self, desc: &str, seminaive: bool) -> RuleBuilder<'_> {
         let uf_table = self.uf_table;
         let id_counter = self.id_counter;
         let ts_counter = self.timestamp_counter;

--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -151,6 +151,11 @@ impl<K: NumericId, V> DenseIdMap<K, V> {
         self.data[key.index()].get_or_insert_with(f)
     }
 
+    pub fn raw(&self) -> &[Option<V>] {
+        let todo_resolve = 1;
+        &self.data
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = (K, &V)> {
         self.data
             .iter()

--- a/numeric-id/src/lib.rs
+++ b/numeric-id/src/lib.rs
@@ -152,7 +152,6 @@ impl<K: NumericId, V> DenseIdMap<K, V> {
     }
 
     pub fn raw(&self) -> &[Option<V>] {
-        let todo_resolve = 1;
         &self.data
     }
 

--- a/union-find/src/concurrent/atomic_int.rs
+++ b/union-find/src/concurrent/atomic_int.rs
@@ -77,39 +77,6 @@ impl AtomicInt for AtomicUsize {
     }
 }
 
-impl<T: AtomicInt> AtomicInt for Padded<T> {
-    type Underlying = T::Underlying;
-
-    fn from_usize(value: usize) -> Self {
-        Padded(T::from_usize(value))
-    }
-    fn as_usize(value: T::Underlying) -> usize {
-        T::as_usize(value)
-    }
-
-    fn load(&self) -> T::Underlying {
-        self.0.load()
-    }
-    fn store(&self, value: T::Underlying) {
-        self.0.store(value)
-    }
-    fn cas(
-        &self,
-        current: T::Underlying,
-        new: T::Underlying,
-    ) -> Result<T::Underlying, T::Underlying> {
-        self.0.cas(current, new)
-    }
-}
-
-/// Pad a given atomic integer type out to a full cache line, avoiding false
-/// sharing.
-///
-/// We aren't currently using this because it doesn't appear to help.
-#[repr(align(64))]
-#[derive(Default)]
-pub(crate) struct Padded<T>(T);
-
 /*
 
 We could do the following, but we don't have good reason to believe it is


### PR DESCRIPTION
These get us pretty close to parity on the `cykjson` benchmark, at least on my machine; I suspect other benchmarks will benefit as well. There are three things going on here:

* Optimizing the process of pushing bindings. This happens quite a lot when there is a large number of matches. The main change is to have a flat representation for bindings, rather than a `DenseIdMap` of `Vec`s. There's also some unsafe code for removing boundschecking, which had a noticeable positive performance impact.
* Managing pending updates via the "frame" subsystem created a lot of repeated allocations and deallocations. This PR flattens the representation of 'frame' into a shared vector.
* It reduces need for `iter_dynamic` over a mask with a macro that special-cases small argument vectors. This was already a technique being used elsewhere in the crate and the macro provides a shared implementation for it.