### PR TITLE
More accurate lifetimes for ExecutionState methods

### DIFF
--- a/core-relations/src/action/mod.rs
+++ b/core-relations/src/action/mod.rs
@@ -419,7 +419,7 @@ impl<'a> ExecutionState<'a> {
 
     /// Get an immutable reference to the table with id `table`.
     /// Dangerous: Reading from a table during action execution may break the semi-naive evaluation
-    pub fn get_table(&self, table: TableId) -> &WrappedTable {
+    pub fn get_table(&self, table: TableId) -> &'a WrappedTable {
         &self.db.table_info[table].table
     }
 
@@ -427,7 +427,7 @@ impl<'a> ExecutionState<'a> {
         self.db.bases
     }
 
-    pub fn container_values(&self) -> &ContainerValues {
+    pub fn container_values(&self) -> &'a ContainerValues {
         self.db.containers
     }
 


### PR DESCRIPTION
Was prototyping some code and found this minor bug. It makes it hard to chain methods `exec_state.container_vals(..., exec_state)`